### PR TITLE
Redesign der Ereignisseiten (neues Layout, Etappen 1–6)

### DIFF
--- a/html/css/theme.css
+++ b/html/css/theme.css
@@ -80,10 +80,11 @@ a:focus {
     --bs-link-hover-color: var(--accent-dark);
 }
 
-/* Fokusring in Akzentfarbe (statt Bootstrap-Blau) */
+/* Sichtbarer Tastatur-Fokusring in Akzentfarbe (statt Bootstrap-Blau) */
 :focus-visible {
-    outline: 0;
-    box-shadow: 0 0 0 .25rem rgba(138, 46, 53, .25);
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    box-shadow: none;
 }
 
 /* =========================================================
@@ -193,7 +194,8 @@ a:focus {
     text-decoration: none;
 }
 
-@media (max-width: 991.98px) {
+/* Burger-Menü-Zustand (Bootstrap navbar-expand-md: unter 768 px) */
+@media (max-width: 767.98px) {
     .site-header .navbar {
         padding: 8px 0;
     }
@@ -263,12 +265,19 @@ a:focus {
 }
 
 .event-nav-kicker {
-    color: var(--ink-faint);
+    color: var(--ink-muted);
 }
 
 .event-nav-arrow {
     flex-shrink: 0;
     color: var(--accent);
+}
+
+/* Datum nur in der kompakten (mobilen) Ansicht */
+.event-nav-date {
+    display: none;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
 }
 
 .event-nav-link:hover,
@@ -313,7 +322,7 @@ a:focus {
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.1em;
-    color: var(--ink-faint);
+    color: var(--ink-muted);
     margin-bottom: 16px;
 }
 
@@ -376,7 +385,7 @@ a:focus {
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.1em;
-    color: var(--ink-faint);
+    color: var(--ink-muted);
     border-bottom: 1px solid var(--line);
     padding: 0 0 10px;
     margin-bottom: 20px;
@@ -405,7 +414,7 @@ a:focus {
     flex-shrink: 0;
     width: 24px;
     font-size: 14px;
-    color: var(--ink-faint);
+    color: var(--ink-muted);
     font-variant-numeric: tabular-nums;
 }
 
@@ -567,7 +576,7 @@ a:focus {
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.1em;
-    color: var(--ink-faint);
+    color: var(--ink-muted);
     margin-bottom: 14px;
 }
 
@@ -612,7 +621,7 @@ a:focus {
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.06em;
-    color: var(--ink-faint);
+    color: var(--ink-muted);
 }
 
 .copy-citation {
@@ -717,17 +726,30 @@ a:focus {
     }
 }
 
+/* style.css blendet <br> auf kleinen Screens aus – im Footer werden
+   die Umbrüche (Adresse) aber gebraucht */
+@media (max-width: 575px) {
+    .site-footer br {
+        display: inline;
+    }
+}
+
 /* ------- Responsiv ------- */
 
 @media (max-width: 999.98px) {
-    /* Ereignis-Navigation kompakt: nur Pfeile + Liste */
+    /* Ereignis-Navigation kompakt: nur Pfeile + Datum */
     .event-nav-inner {
         padding: 0 20px;
         gap: 12px;
     }
 
-    .event-nav-kicker {
+    .event-nav-kicker,
+    .event-nav-text {
         display: none;
+    }
+
+    .event-nav-date {
+        display: inline;
     }
 
     .event-title {

--- a/html/css/theme.css
+++ b/html/css/theme.css
@@ -1,0 +1,87 @@
+/* =========================================================
+   schnitzler-kultur – Design-Tokens + Basis-Stile
+   Wird NACH Bootstrap und style.css geladen und
+   überschreibt deren Grundwerte.
+   ========================================================= */
+
+:root {
+    /* Flächen */
+    --bg: #FAF8F5;            /* warmes Weiß */
+    --surface: #FFFFFF;
+    --surface-2: #F4F0EA;
+
+    /* Text */
+    --ink: #211E1C;
+    --ink-muted: #6B645C;
+    --ink-faint: #9A9288;
+
+    /* Linien */
+    --line: #E5DFD6;
+    --line-soft: #F0EBE3;
+
+    /* Akzent */
+    --accent: #8A2E35;        /* Bordeaux */
+    --accent-dark: #5E1F24;
+
+    /* Schrift */
+    --font-sans: "Source Sans 3", "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+/* ------- Basis ------- */
+
+body {
+    background-color: var(--bg);
+    color: var(--ink);
+    font-family: var(--font-sans);
+}
+
+h1, h2, h3, h4, h5, h6,
+.h1, .h2, .h3, .h4, .h5, .h6 {
+    font-family: var(--font-sans);
+    color: var(--ink);
+}
+
+/* keine Serifenschrift – auch in Editionstexten */
+.card-body-text,
+.editionText,
+.list-for-footnotes {
+    font-family: var(--font-sans);
+}
+
+/* ------- Links ------- */
+
+a,
+a:visited {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+a:hover,
+a:focus {
+    color: var(--accent-dark);
+    text-decoration: underline;
+}
+
+/* Buttons/Nav-Links nicht unterstreichen */
+.btn:hover,
+.nav-link:hover,
+.navbar-brand:hover,
+.dropdown-item:hover,
+.page-link:hover {
+    text-decoration: none;
+}
+
+/* Bootstrap-Variablen auf die Tokens mappen */
+:root {
+    --bs-body-bg: var(--bg);
+    --bs-body-color: var(--ink);
+    --bs-body-font-family: var(--font-sans);
+    --bs-link-color: var(--accent);
+    --bs-link-hover-color: var(--accent-dark);
+}
+
+/* Fokusring in Akzentfarbe (statt Bootstrap-Blau) */
+:focus-visible {
+    outline: 0;
+    box-shadow: 0 0 0 .25rem rgba(138, 46, 53, .25);
+}

--- a/html/css/theme.css
+++ b/html/css/theme.css
@@ -352,6 +352,304 @@ a:focus {
     white-space: nowrap;
 }
 
+/* =========================================================
+   Ereignisseite: zweispaltiger Inhalt
+   ========================================================= */
+
+.event-body {
+    display: grid;
+    grid-template-columns: 1fr 380px;
+    gap: 72px;
+    max-width: 1200px;
+    margin: 24px auto 64px;
+    align-items: start;
+}
+
+/* ------- Hauptspalte ------- */
+
+.event-section {
+    margin-bottom: 48px;
+}
+
+.event-section-title {
+    font-size: 13px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--ink-faint);
+    border-bottom: 1px solid var(--line);
+    padding: 0 0 10px;
+    margin-bottom: 20px;
+}
+
+/* Werkliste */
+.work-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.work-item {
+    display: flex;
+    align-items: baseline;
+    gap: 18px;
+    padding: 14px 0;
+    border-bottom: 1px solid var(--line-soft);
+}
+
+.work-item:last-child {
+    border-bottom: none;
+}
+
+.work-num {
+    flex-shrink: 0;
+    width: 24px;
+    font-size: 14px;
+    color: var(--ink-faint);
+    font-variant-numeric: tabular-nums;
+}
+
+.work-info {
+    flex: 1;
+    min-width: 0;
+}
+
+.work-title {
+    font-size: 22px;
+    font-weight: 600;
+    line-height: 1.3;
+    color: var(--ink);
+}
+
+.work-title:hover {
+    color: var(--accent-dark);
+}
+
+.work-meta {
+    font-size: 14px;
+    color: var(--ink-muted);
+    margin: 2px 0 0;
+}
+
+.work-link {
+    flex-shrink: 0;
+    font-size: 14px;
+    white-space: nowrap;
+}
+
+/* Personen-Chips */
+.person-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.person-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    padding: 6px 16px 6px 6px;
+    color: var(--ink);
+    transition: border-color 0.15s ease;
+}
+
+.person-chip:hover,
+.person-chip:focus {
+    border-color: var(--accent);
+    color: var(--ink);
+    text-decoration: none;
+}
+
+.chip-avatar {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
+    background: var(--accent);
+    color: #fff;
+    font-size: 13px;
+    font-weight: 600;
+    flex-shrink: 0;
+}
+
+.chip-body {
+    display: flex;
+    flex-direction: column;
+    line-height: 1.25;
+}
+
+.chip-name {
+    font-size: 15px;
+    font-weight: 600;
+}
+
+.chip-role {
+    font-size: 12px;
+    color: var(--ink-muted);
+}
+
+/* Zeitungs-Karten */
+.newspaper-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+}
+
+.newspaper-card {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 16px 20px;
+    color: var(--ink);
+    transition: border-color 0.15s ease;
+}
+
+.newspaper-card:hover,
+.newspaper-card:focus {
+    border-color: var(--accent);
+    color: var(--ink);
+    text-decoration: none;
+}
+
+.newspaper-card-title {
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.newspaper-card-sub {
+    font-size: 13px;
+    color: var(--ink-muted);
+}
+
+/* ------- Seitenleiste ------- */
+
+.event-side {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.side-card {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.side-card-map {
+    height: 220px;
+    width: 100%;
+    border-bottom: 1px solid var(--line);
+    z-index: 0;
+}
+
+.side-card-body {
+    padding: 20px 24px 22px;
+}
+
+.side-card-title {
+    font-size: 24px;
+    font-weight: 700;
+    padding: 0;
+    margin: 0 0 6px;
+}
+
+.side-card-title-small {
+    font-size: 13px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--ink-faint);
+    margin-bottom: 14px;
+}
+
+.side-card-sub {
+    font-size: 14px;
+    color: var(--ink-muted);
+    margin: 0 0 4px;
+}
+
+.side-card-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 20px;
+    font-size: 14px;
+    margin: 10px 0 0;
+}
+
+/* Datensatz-Zeilen */
+.record-list {
+    list-style: none;
+    margin: 0 0 16px;
+    padding: 0;
+}
+
+.record-list li {
+    display: flex;
+    align-items: baseline;
+    gap: 14px;
+    padding: 7px 0;
+    border-bottom: 1px solid var(--line-soft);
+    font-size: 14px;
+}
+
+.record-list li:last-child {
+    border-bottom: none;
+}
+
+.record-label {
+    flex-shrink: 0;
+    width: 72px;
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--ink-faint);
+}
+
+.copy-citation {
+    width: 100%;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    background: var(--surface-2);
+    color: var(--ink);
+    font-size: 14px;
+    font-weight: 600;
+    padding: 9px 14px;
+}
+
+.copy-citation:hover {
+    border-color: var(--accent);
+    color: var(--accent-dark);
+}
+
+.copy-citation.copied {
+    border-color: var(--accent);
+    color: var(--accent-dark);
+    background: var(--surface);
+}
+
+/* Kontext-Karte */
+.side-card-context {
+    background: var(--surface-2);
+}
+
+.side-card-context-text {
+    font-size: 15px;
+    color: var(--ink);
+    margin: 0;
+}
+
+/* ------- Responsiv ------- */
+
 @media (max-width: 999.98px) {
     /* Ereignis-Navigation kompakt: nur Pfeile + Liste */
     .event-nav-inner {
@@ -373,5 +671,12 @@ a:focus {
 
     .event-date {
         font-size: 19px;
+    }
+
+    /* Seitenleiste unter die Hauptspalte */
+    .event-body {
+        grid-template-columns: 1fr;
+        gap: 40px;
+        margin-bottom: 48px;
     }
 }

--- a/html/css/theme.css
+++ b/html/css/theme.css
@@ -221,3 +221,157 @@ a:focus {
         font-size: 11px;
     }
 }
+
+/* =========================================================
+   Ereignisseite: Prev/Next-Navigation
+   ========================================================= */
+
+.event-nav {
+    background: var(--surface-2);
+    border-bottom: 1px solid var(--line);
+}
+
+.event-nav-inner {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    gap: 24px;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 32px;
+    height: 48px;
+}
+
+.event-nav-link {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    font-size: 14px;
+    color: var(--ink-muted);
+}
+
+.event-nav-next {
+    justify-content: flex-end;
+    text-align: right;
+}
+
+.event-nav-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.event-nav-kicker {
+    color: var(--ink-faint);
+}
+
+.event-nav-arrow {
+    flex-shrink: 0;
+    color: var(--accent);
+}
+
+.event-nav-link:hover,
+.event-nav-link:focus {
+    color: var(--accent-dark);
+    text-decoration: none;
+}
+
+.event-nav-link:hover .event-nav-text {
+    text-decoration: underline;
+}
+
+.event-nav-all {
+    flex-shrink: 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--ink);
+    white-space: nowrap;
+}
+
+.event-nav-all:hover,
+.event-nav-all:focus {
+    color: var(--accent-dark);
+}
+
+/* =========================================================
+   Ereignisseite: Artikelkopf
+   ========================================================= */
+
+.event-article {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0;
+}
+
+.event-head {
+    padding: 48px 0 8px;
+}
+
+.event-kicker {
+    font-size: 13px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--ink-faint);
+    margin-bottom: 16px;
+}
+
+.event-kicker-type {
+    color: var(--accent);
+}
+
+.event-title {
+    font-size: 48px;
+    font-weight: 700;
+    line-height: 1.15;
+    max-width: 820px;
+    text-align: left;
+    padding: 0;
+    margin: 0 0 16px;
+}
+
+.event-title em {
+    font-style: italic;
+}
+
+.event-date {
+    font-size: 24px;
+    font-style: italic;
+    color: var(--ink-muted);
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 8px 24px;
+    margin-bottom: 8px;
+}
+
+.event-date-link {
+    font-size: 15px;
+    font-style: normal;
+    white-space: nowrap;
+}
+
+@media (max-width: 999.98px) {
+    /* Ereignis-Navigation kompakt: nur Pfeile + Liste */
+    .event-nav-inner {
+        padding: 0 20px;
+        gap: 12px;
+    }
+
+    .event-nav-kicker {
+        display: none;
+    }
+
+    .event-title {
+        font-size: 32px;
+    }
+
+    .event-head {
+        padding: 32px 0 8px;
+    }
+
+    .event-date {
+        font-size: 19px;
+    }
+}

--- a/html/css/theme.css
+++ b/html/css/theme.css
@@ -648,6 +648,75 @@ a:focus {
     margin: 0;
 }
 
+/* =========================================================
+   Footer
+   ========================================================= */
+
+.site-footer {
+    margin-top: auto;
+    background: var(--ink);
+    color: #C9C0B4;
+    font-size: 14px;
+    line-height: 1.6;
+}
+
+.site-footer-inner {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 48px;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 48px 32px 40px;
+}
+
+.site-footer-title {
+    color: #fff;
+    font-size: 15px;
+    font-weight: 600;
+    margin-bottom: 12px;
+}
+
+.site-footer p {
+    margin-bottom: 12px;
+}
+
+.site-footer a,
+.site-footer a:visited {
+    color: var(--bg);
+}
+
+.site-footer a:hover,
+.site-footer a:focus {
+    color: #fff;
+    text-decoration: underline;
+}
+
+.site-footer-links {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.site-footer-links li {
+    margin-bottom: 8px;
+}
+
+.site-footer-bar {
+    border-top: 1px solid #3A3530;
+    text-align: center;
+    font-size: 13px;
+    color: #9A9288;
+    padding: 14px 20px;
+}
+
+@media (max-width: 767.98px) {
+    .site-footer-inner {
+        grid-template-columns: 1fr;
+        gap: 28px;
+        padding: 36px 20px 28px;
+    }
+}
+
 /* ------- Responsiv ------- */
 
 @media (max-width: 999.98px) {

--- a/html/css/theme.css
+++ b/html/css/theme.css
@@ -85,3 +85,139 @@ a:focus {
     outline: 0;
     box-shadow: 0 0 0 .25rem rgba(138, 46, 53, .25);
 }
+
+/* =========================================================
+   Header / Hauptnavigation
+   ========================================================= */
+
+.site-header {
+    position: sticky;
+    top: 0;
+    z-index: 1030;
+    background: var(--bg);
+    border-bottom: 1px solid var(--line);
+}
+
+/* Altlasten aus style.css neutralisieren */
+.site-header .navbar {
+    background: var(--bg);
+    border-bottom: none;
+    box-shadow: none;
+    display: flex;
+    font-size: 1rem;
+    min-height: 64px;
+    padding: 0;
+}
+
+.site-header .navbar .container-fluid {
+    max-width: 1200px;
+    padding-left: 32px;
+    padding-right: 32px;
+}
+
+/* Wortmarke */
+.brand-wordmark {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    text-decoration: none;
+}
+
+.brand-name {
+    font-size: 22px;
+    font-weight: 600;
+    color: var(--ink);
+    line-height: 1;
+}
+
+.brand-sub {
+    font-size: 13px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--accent);
+    line-height: 1;
+}
+
+.brand-wordmark:hover .brand-name {
+    color: var(--accent-dark);
+}
+
+/* Navigationslinks */
+.site-nav .nav-link {
+    color: var(--ink);
+    font-size: 15px;
+    padding: 0.5rem 0.75rem;
+}
+
+.site-nav .nav-link:hover,
+.site-nav .nav-link:focus {
+    color: var(--accent-dark);
+}
+
+.site-nav .dropdown-menu {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    box-shadow: 0 6px 24px rgba(33, 30, 28, 0.08);
+}
+
+.site-nav .dropdown-item {
+    color: var(--ink);
+}
+
+.site-nav .dropdown-item:hover,
+.site-nav .dropdown-item:focus {
+    color: var(--accent-dark);
+    background-color: var(--surface-2);
+}
+
+/* Such-Pill */
+.search-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    padding: 6px 16px;
+    margin-left: 12px;
+    font-size: 14px;
+    color: var(--ink-muted);
+    background: var(--surface);
+}
+
+.search-pill:hover,
+.search-pill:focus {
+    color: var(--accent-dark);
+    border-color: var(--accent);
+    text-decoration: none;
+}
+
+@media (max-width: 991.98px) {
+    .site-header .navbar {
+        padding: 8px 0;
+    }
+
+    .site-header .navbar .container-fluid {
+        padding-left: 20px;
+        padding-right: 20px;
+    }
+
+    .search-pill {
+        margin-left: 0;
+        margin-top: 8px;
+    }
+}
+
+@media (max-width: 575.98px) {
+    /* Wortmarke stapeln, damit der Menü-Button daneben Platz hat */
+    .brand-wordmark {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 3px;
+    }
+
+    .brand-sub {
+        font-size: 11px;
+    }
+}

--- a/html/js/citation.js
+++ b/html/js/citation.js
@@ -1,0 +1,41 @@
+/**
+ * Zitiervorschlag in die Zwischenablage kopieren.
+ * Buttons mit der Klasse .copy-citation tragen den Text im
+ * data-citation-Attribut; {DATUM} wird durch das Abfragedatum ersetzt.
+ */
+document.addEventListener('click', function (e) {
+    var btn = e.target.closest('.copy-citation');
+    if (!btn || !btn.dataset.citation) return;
+
+    var heute = new Date().toLocaleDateString('de-AT', {
+        day: '2-digit', month: '2-digit', year: 'numeric'
+    });
+    var text = btn.dataset.citation.replace('{DATUM}', heute);
+
+    function feedback() {
+        if (btn.dataset.origLabel) return;
+        btn.dataset.origLabel = btn.textContent;
+        btn.textContent = 'Zitation kopiert ✓';
+        btn.classList.add('copied');
+        setTimeout(function () {
+            btn.textContent = btn.dataset.origLabel;
+            delete btn.dataset.origLabel;
+            btn.classList.remove('copied');
+        }, 2000);
+    }
+
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(feedback);
+    } else {
+        // Fallback für ältere Browser
+        var ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand('copy');
+        document.body.removeChild(ta);
+        feedback();
+    }
+});

--- a/xslt/listevent.xsl
+++ b/xslt/listevent.xsl
@@ -260,7 +260,18 @@
                 <script src="tabulator-js/tabulator_event.js"/>
             </body>
         </html>
-        <xsl:for-each select=".//tei:event[@xml:id]">
+        <!-- Ereignisse chronologisch sortieren, um Vorgänger/Nachfolger zu bestimmen -->
+        <xsl:variable name="sorted-events" as="element()*">
+            <xsl:perform-sort select=".//tei:event[@xml:id]">
+                <xsl:sort
+                    select="string((@when-iso, @from-iso, @notBefore-iso, @to-iso, @notAfter-iso, '9999-12-31')[1])"
+                    data-type="text"/>
+            </xsl:perform-sort>
+        </xsl:variable>
+        <xsl:for-each select="$sorted-events">
+            <xsl:variable name="pos" select="position()"/>
+            <xsl:variable name="prev" select="$sorted-events[$pos - 1]"/>
+            <xsl:variable name="next" select="$sorted-events[$pos + 1]"/>
             <xsl:variable name="filename" select="concat(./@xml:id, '.html')"/>
             <xsl:variable name="name"
                 select="normalize-space(string-join(./tei:eventName[1]//text()))"/>
@@ -284,9 +295,49 @@
                     </head>
                     <body class="d-flex flex-column h-100">
                         <xsl:call-template name="nav_bar"/>
+                        <nav class="event-nav" aria-label="Ereignis-Navigation">
+                            <div class="event-nav-inner">
+                                <xsl:choose>
+                                    <xsl:when test="$prev">
+                                        <a class="event-nav-link event-nav-prev"
+                                            href="{concat($prev/@xml:id, '.html')}"
+                                            title="{normalize-space($prev/tei:eventName[1])}">
+                                            <span class="event-nav-arrow" aria-hidden="true">←</span>
+                                            <span class="event-nav-text">
+                                                <span class="event-nav-kicker">Vorheriges: </span>
+                                                <xsl:value-of
+                                                  select="normalize-space($prev/tei:eventName[1])"/>
+                                            </span>
+                                        </a>
+                                    </xsl:when>
+                                    <xsl:otherwise>
+                                        <span class="event-nav-link event-nav-prev"/>
+                                    </xsl:otherwise>
+                                </xsl:choose>
+                                <a class="event-nav-all" href="listevent.html">Alle
+                                    Veranstaltungen</a>
+                                <xsl:choose>
+                                    <xsl:when test="$next">
+                                        <a class="event-nav-link event-nav-next"
+                                            href="{concat($next/@xml:id, '.html')}"
+                                            title="{normalize-space($next/tei:eventName[1])}">
+                                            <span class="event-nav-text">
+                                                <span class="event-nav-kicker">Nächstes: </span>
+                                                <xsl:value-of
+                                                  select="normalize-space($next/tei:eventName[1])"/>
+                                            </span>
+                                            <span class="event-nav-arrow" aria-hidden="true">→</span>
+                                        </a>
+                                    </xsl:when>
+                                    <xsl:otherwise>
+                                        <span class="event-nav-link event-nav-next"/>
+                                    </xsl:otherwise>
+                                </xsl:choose>
+                            </div>
+                        </nav>
                         <main class="flex-shrink-0 flex-grow-1">
                             <div class="container">
-                                <xsl:call-template name="event_detail"/> 
+                                <xsl:call-template name="event_detail"/>
                             </div>
                         </main>
                         <xsl:call-template name="html_footer"/>

--- a/xslt/listevent.xsl
+++ b/xslt/listevent.xsl
@@ -342,24 +342,25 @@
                         </main>
                         <xsl:call-template name="html_footer"/>
                     </body>
-                    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-                        integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
-                        crossorigin=""/>
-                    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""/>
-                    <script>
+                    <xsl:if test="descendant::tei:location[1]/tei:geo[1]">
+                        <script>
                             var lat = <xsl:value-of select="replace(tokenize(descendant::tei:location[1]/tei:geo[1]/text(), ' ')[1], ',', '.')"/>;
                             var long = <xsl:value-of select="replace(tokenize(descendant::tei:location[1]/tei:geo[1]/text(), ' ')[2], ',', '.')"/>;
-                            $("#map_detail").css("height", "300px");
-                            var map = L.map('map_detail').setView([Number(lat), Number(long)], 13);
+                            var mapEl = document.getElementById('map_detail');
+                            if (mapEl &amp;&amp; typeof L !== 'undefined') {
+                            var map = L.map('map_detail', { scrollWheelZoom: false }).setView([Number(lat), Number(long)], 14);
                             L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
                             maxZoom: 19,
                             attribution: '&amp;copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &amp;copy; <a href="https://carto.com/attributions">CARTO</a>'
                             }).addTo(map);
-                            var marker = L.marker([Number(lat), Number(long)]).addTo(map);
+                            L.circleMarker([Number(lat), Number(long)], {
+                            radius: 9, color: '#8A2E35', weight: 2,
+                            fillColor: '#8A2E35', fillOpacity: 0.85
+                            }).addTo(map);
+                            }
                         </script>
-                    <link
-                        href="https://unpkg.com/tabulator-tables@6.2.1/dist/css/tabulator_bootstrap5.min.css"
-                        rel="stylesheet"/>
+                    </xsl:if>
+                    <script src="js/citation.js" defer="defer"/>
                 </html>
             </xsl:result-document>
         </xsl:for-each>

--- a/xslt/listevent.xsl
+++ b/xslt/listevent.xsl
@@ -299,6 +299,8 @@
                             <div class="event-nav-inner">
                                 <xsl:choose>
                                     <xsl:when test="$prev">
+                                        <xsl:variable name="prevdate"
+                                            select="string(($prev/@when-iso, $prev/@from-iso, $prev/@notBefore-iso, $prev/@to-iso, $prev/@notAfter-iso)[1])"/>
                                         <a class="event-nav-link event-nav-prev"
                                             href="{concat($prev/@xml:id, '.html')}"
                                             title="{normalize-space($prev/tei:eventName[1])}">
@@ -308,6 +310,13 @@
                                                 <xsl:value-of
                                                   select="normalize-space($prev/tei:eventName[1])"/>
                                             </span>
+                                            <xsl:if test="$prevdate != ''">
+                                                <span class="event-nav-date">
+                                                  <xsl:value-of
+                                                  select="concat(substring($prevdate, 9, 2), '.', substring($prevdate, 6, 2), '.', substring($prevdate, 1, 4))"
+                                                  />
+                                                </span>
+                                            </xsl:if>
                                         </a>
                                     </xsl:when>
                                     <xsl:otherwise>
@@ -318,6 +327,8 @@
                                     Veranstaltungen</a>
                                 <xsl:choose>
                                     <xsl:when test="$next">
+                                        <xsl:variable name="nextdate"
+                                            select="string(($next/@when-iso, $next/@from-iso, $next/@notBefore-iso, $next/@to-iso, $next/@notAfter-iso)[1])"/>
                                         <a class="event-nav-link event-nav-next"
                                             href="{concat($next/@xml:id, '.html')}"
                                             title="{normalize-space($next/tei:eventName[1])}">
@@ -326,6 +337,13 @@
                                                 <xsl:value-of
                                                   select="normalize-space($next/tei:eventName[1])"/>
                                             </span>
+                                            <xsl:if test="$nextdate != ''">
+                                                <span class="event-nav-date">
+                                                  <xsl:value-of
+                                                  select="concat(substring($nextdate, 9, 2), '.', substring($nextdate, 6, 2), '.', substring($nextdate, 1, 4))"
+                                                  />
+                                                </span>
+                                            </xsl:if>
                                             <span class="event-nav-arrow" aria-hidden="true">→</span>
                                         </a>
                                     </xsl:when>

--- a/xslt/partials/event.xsl
+++ b/xslt/partials/event.xsl
@@ -16,12 +16,107 @@
             <xsl:value-of select="concat(data(@xml:id), '.html')"/>
         </xsl:variable>
         <div class="container-fluid">
-            <div class="card-body-index">
-                <xsl:if test="normalize-space(tei:eventName[1])">
-                    <h1 class="text-center">
-                        <xsl:value-of select="normalize-space(tei:eventName[1])"/>
-                    </h1>
-                </xsl:if>
+            <div class="event-article">
+                <header class="event-head">
+                    <p class="event-kicker">
+                        <span class="event-kicker-type">
+                            <xsl:choose>
+                                <xsl:when test="normalize-space(tei:eventName[1]/@n)">
+                                    <xsl:value-of select="tei:eventName[1]/@n"/>
+                                </xsl:when>
+                                <xsl:otherwise>Veranstaltung</xsl:otherwise>
+                            </xsl:choose>
+                        </span>
+                        <span class="event-kicker-sep" aria-hidden="true"> — </span>
+                        <span class="event-kicker-id">
+                            <xsl:text>PMB </xsl:text>
+                            <xsl:value-of select="substring-after(@xml:id, 'pmb')"/>
+                        </span>
+                    </p>
+                    <xsl:if test="normalize-space(tei:eventName[1])">
+                        <xsl:variable name="titletext"
+                            select="normalize-space(tei:eventName[1])"/>
+                        <xsl:variable name="firstwork"
+                            select="normalize-space(tei:listBibl/tei:bibl[not(tei:note[contains(., 'rezensi')])][1]/tei:title)"/>
+                        <h1 class="event-title">
+                            <xsl:choose>
+                                <!-- Werktitel im Ereignisnamen kursiv auszeichnen -->
+                                <xsl:when
+                                    test="$firstwork != '' and contains($titletext, $firstwork)">
+                                    <xsl:value-of
+                                        select="substring-before($titletext, $firstwork)"/>
+                                    <em>
+                                        <xsl:value-of select="$firstwork"/>
+                                    </em>
+                                    <xsl:value-of
+                                        select="substring-after($titletext, $firstwork)"/>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:value-of select="$titletext"/>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                        </h1>
+                    </xsl:if>
+                    <p class="event-date">
+                        <span class="event-date-text">
+                            <xsl:choose>
+                                <xsl:when test="@from-iso and @to-iso">
+                                    <xsl:value-of select="mam:wochentag(@from-iso)"/>
+                                    <xsl:text>, </xsl:text>
+                                    <xsl:value-of select="format-date(@from-iso, '[D1]. ')"/>
+                                    <xsl:value-of select="mam:monat(@from-iso)"/>
+                                    <xsl:value-of select="format-date(@from-iso, ' [Y]')"/>
+                                    <xsl:text> bis </xsl:text>
+                                    <xsl:value-of select="mam:wochentag(@to-iso)"/>
+                                    <xsl:text>, </xsl:text>
+                                    <xsl:value-of select="format-date(@to-iso, '[D1]. ')"/>
+                                    <xsl:value-of select="mam:monat(@to-iso)"/>
+                                    <xsl:value-of select="format-date(@to-iso, ' [Y]')"/>
+                                </xsl:when>
+                                <xsl:when
+                                    test="(@from-iso = '' or not(@from-iso)) and @to-iso">
+                                    <xsl:text>bis </xsl:text>
+                                    <xsl:value-of select="mam:wochentag(@to-iso)"/>
+                                    <xsl:text>, </xsl:text>
+                                    <xsl:value-of select="format-date(@to-iso, '[D1]. ')"/>
+                                    <xsl:value-of select="mam:monat(@to-iso)"/>
+                                    <xsl:value-of select="format-date(@to-iso, ' [Y]')"/>
+                                </xsl:when>
+                                <xsl:when test="@when-iso">
+                                    <xsl:value-of select="mam:wochentag(@when-iso)"/>
+                                    <xsl:text>, </xsl:text>
+                                    <xsl:value-of select="format-date(@when-iso, '[D1]. ')"/>
+                                    <xsl:value-of select="mam:monat(@when-iso)"/>
+                                    <xsl:value-of select="format-date(@when-iso, ' [Y]')"/>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:text>Datum unbekannt</xsl:text>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                        </span>
+                        <xsl:if test="@when-iso">
+                            <a class="event-date-link" target="_blank">
+                                <xsl:attribute name="href">
+                                    <xsl:value-of
+                                        select="concat('https://schnitzler-chronik.acdh.oeaw.ac.at/', @when-iso, '.html')"
+                                    />
+                                </xsl:attribute>
+                                <xsl:text>Dieser Tag in der Chronik →</xsl:text>
+                            </a>
+                            <xsl:variable name="when" select="@when-iso"/>
+                            <xsl:if test="$tb-days/descendant::*:date[. = $when][1]">
+                                <a class="event-date-link" target="_blank">
+                                    <xsl:attribute name="href">
+                                        <xsl:value-of
+                                            select="concat('https://schnitzler-tagebuch.acdh.oeaw.ac.at/entry__', $when, '.html')"
+                                        />
+                                    </xsl:attribute>
+                                    <xsl:text>Dieser Tag im Tagebuch →</xsl:text>
+                                </a>
+                            </xsl:if>
+                        </xsl:if>
+                    </p>
+                </header>
                 <div id="mentions">
                     <xsl:if test="key('only-relevant-uris', tei:idno/@subtype, $relevant-uris)[1]">
                         <p class="buttonreihe">
@@ -38,91 +133,10 @@
                         </p>
                     </xsl:if>
                 </div>
-                
+
                 <xsl:variable name="xmlid" select="@xml:id"/>
                 <table class="table entity-table mx-auto" style="max-width: 800px;">
                     <tbody>
-                        <tr>
-                            <th> Datum </th>
-                            <td>
-                                <ul>
-                                    <li>
-                                <xsl:choose>
-                                    <xsl:when test="@from-iso and @to-iso">
-                                        <xsl:value-of select="mam:wochentag(@from-iso)"/>
-                                        <xsl:text>, </xsl:text>
-                                        <xsl:value-of
-                                            select="format-date(@from-iso, '[D1]. ')"/>
-                                        <xsl:value-of select="mam:monat(@from-iso)"/>
-                                        <xsl:value-of
-                                            select="format-date(@from-iso, ' [Y]')"/>
-                                        <xsl:text> bis </xsl:text>
-                                        <xsl:value-of select="mam:wochentag(@to-iso)"/>
-                                        <xsl:text>, </xsl:text>
-                                        <xsl:value-of
-                                            select="format-date(@to-iso, '[D1]. ')"/>
-                                        <xsl:value-of select="mam:monat(@to-iso)"/>
-                                        <xsl:value-of select="format-date(@to-iso, ' [Y]')"
-                                        />
-                                    </xsl:when>
-                                    <xsl:when
-                                        test="(@from-iso = '' or not(@from-iso)) and @to-iso">
-                                        <xsl:text>bis </xsl:text>
-                                        <xsl:value-of select="mam:wochentag(@to-iso)"/>
-                                        <xsl:text>, </xsl:text>
-                                        <xsl:value-of
-                                            select="format-date(@to-iso, '[D1]. ')"/>
-                                        <xsl:value-of select="mam:monat(@to-iso)"/>
-                                        <xsl:value-of select="format-date(@to-iso, ' [Y]')"
-                                        />
-                                    </xsl:when>
-                                    <xsl:otherwise>
-                                        <xsl:value-of select="mam:wochentag(@when-iso)"/>
-                                        <xsl:text>, </xsl:text>
-                                        <xsl:value-of
-                                            select="format-date(@when-iso, '[D1]. ')"/>
-                                        <xsl:value-of select="mam:monat(@when-iso)"/>
-                                        <xsl:value-of
-                                            select="format-date(@when-iso, ' [Y]')"/>
-                                    </xsl:otherwise>
-                                </xsl:choose>
-                                <xsl:text> </xsl:text>
-                                <xsl:element name="a">
-                                    <xsl:attribute name="class">
-                                        <xsl:text>schnitzler-chronik-link ms-3</xsl:text>
-                                    </xsl:attribute>
-                                    <xsl:attribute name="target">
-                                        <xsl:text>_blank</xsl:text>
-                                    </xsl:attribute>
-                                    <xsl:attribute name="href">
-                                        <xsl:value-of
-                                            select="concat('https://schnitzler-chronik.acdh.oeaw.ac.at/', @when-iso, '.html')"
-                                        />
-                                    </xsl:attribute>
-                                    <xsl:text>zur Chronik</xsl:text>
-                                </xsl:element>
-                                <xsl:variable name="when" select="@when-iso"/>
-                                <xsl:text> </xsl:text>
-                                <xsl:if test="$tb-days/descendant::*:date[. = $when][1]">
-                                    <xsl:element name="a">
-                                        <xsl:attribute name="class">
-                                            <xsl:text>schnitzler-tagebuch-link ms-3</xsl:text>
-                                        </xsl:attribute>
-                                        <xsl:attribute name="target">
-                                            <xsl:text>_blank</xsl:text>
-                                        </xsl:attribute>
-                                        <xsl:attribute name="href">
-                                            <xsl:value-of
-                                                select="concat('https://schnitzler-tagebuch.acdh.oeaw.ac.at/entry__', $when, '.html')"
-                                            />
-                                        </xsl:attribute>
-                                        <xsl:text>zum Tagebuch</xsl:text>
-                                    </xsl:element>
-                                </xsl:if>
-                                    </li>
-                                </ul>
-                            </td>
-                        </tr>
                         <tr>
                             <th>Veranstaltungsort</th>
                             <td>

--- a/xslt/partials/event.xsl
+++ b/xslt/partials/event.xsl
@@ -2,14 +2,19 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tei="http://www.tei-c.org/ns/1.0"
     xmlns:mam="whatever" version="2.0" exclude-result-prefixes="xsl tei xs">
-    
+
     <xsl:import href="./LOD-idnos.xsl"/>
     <xsl:param name="current-edition" select="'schnitzler-kultur'"/>
     <xsl:param name="current-colour" select="'#AC7790'"/>
     <xsl:param select="document('../utils/index_days.xml')" name="tb-days"/>
-    <!-- Diese Ansicht ist eine Kopie der betreffenden Stelle aus entitities.xsl mit
-    den Anpassungen für Links zum Tagebuch und zu ANNO etc. -->
-    
+    <xsl:param select="document('../../data/indices/listbibl.xml')" name="works-index"/>
+
+    <!-- Alle Ereignisse eines Ortes (für die Kontext-Karte) -->
+    <xsl:key name="events-by-place" match="tei:event"
+        use="tei:listPlace/tei:place/tei:placeName/@key"/>
+    <!-- Werke im Werkverzeichnis (für Autor/Jahr) -->
+    <xsl:key name="work-by-id" match="tei:bibl[@xml:id]" use="@xml:id"/>
+
     <xsl:template match="tei:event" name="event_detail">
         <xsl:param name="showNumberOfMentions" as="xs:integer" select="50000"/>
         <xsl:variable name="selfLink">
@@ -117,306 +122,396 @@
                         </xsl:if>
                     </p>
                 </header>
-                <div id="mentions">
-                    <xsl:if test="key('only-relevant-uris', tei:idno/@subtype, $relevant-uris)[1]">
-                        <p class="buttonreihe">
-                            <xsl:variable name="idnos-of-current" as="node()">
-                                <xsl:element name="nodeset_place">
-                                    <xsl:for-each select="tei:idno[not(@subtype='schnitzler-kultur')]">
-                                        <xsl:copy-of select="."/>
-                                    </xsl:for-each>
-                                </xsl:element>
-                            </xsl:variable>
-                            <xsl:call-template name="mam:idnosToLinks">
-                                <xsl:with-param name="idnos-of-current" select="$idnos-of-current"/>
-                            </xsl:call-template>
-                        </p>
-                    </xsl:if>
-                </div>
 
-                <xsl:variable name="xmlid" select="@xml:id"/>
-                <table class="table entity-table mx-auto" style="max-width: 800px;">
-                    <tbody>
-                        <tr>
-                            <th>Veranstaltungsort</th>
-                            <td>
-                                <ul>
-                                    <xsl:for-each select="tei:listPlace/tei:place">
-                                        <li>
-                                            <!-- Link zum Ort -->
-                                            <xsl:element name="a">
-                                                <xsl:attribute name="target">_blank</xsl:attribute>
-                                                <xsl:attribute name="href">
+                <div class="event-body">
+                    <div class="event-main">
+
+                        <!-- Aufgeführte Werke -->
+                        <xsl:variable name="werke"
+                            select="tei:listBibl/tei:bibl[not(tei:note[contains(., 'rezensi')]) and normalize-space(tei:title)]"/>
+                        <xsl:if test="$werke">
+                            <section class="event-section">
+                                <h2 class="event-section-title">Aufgeführte Werke</h2>
+                                <ol class="work-list">
+                                    <xsl:for-each select="$werke">
+                                        <xsl:variable name="workkey"
+                                            select="tei:title/@key"/>
+                                        <xsl:variable name="workentry"
+                                            select="key('work-by-id', $workkey, $works-index)[1]"/>
+                                        <li class="work-item">
+                                            <span class="work-num">
+                                                <xsl:value-of select="position()"/>
+                                            </span>
+                                            <div class="work-info">
+                                                <a class="work-title"
+                                                  href="{concat($workkey, '.html')}">
                                                   <xsl:value-of
-                                                  select="concat(tei:placeName/@key, '.html')"/>
-                                                </xsl:attribute>
-                                                <xsl:value-of
-                                                  select="normalize-space(tei:placeName)"/>
-                                            </xsl:element>
-                                            <!-- Karte & OSM-Link -->
-                                            <xsl:if test="./tei:location/tei:geo">
-                                                <!-- Karte -->
-                                                <div id="map_detail"
-                                                  style="height: 250px; width: 475px;"/>
-                                                <!-- Koordinaten vorbereiten -->
-                                                <xsl:variable name="mlat"
-                                                  select="replace(tokenize(./tei:location[1]/tei:geo[1], '\s')[1], ',', '.')"/>
-                                                <xsl:variable name="mlong"
-                                                  select="replace(tokenize(./tei:location[1]/tei:geo[1], '\s')[2], ',', '.')"/>
-                                                <xsl:variable name="mappin"
-                                                  select="concat('mlat=', $mlat, '&amp;mlon=', $mlong)"
-                                                  as="xs:string"/>
-                                                <xsl:variable name="openstreetmapurl"
-                                                  select="concat('https://www.openstreetmap.org/?', $mappin, '#map=12/', $mlat, '/', $mlong)"/>
-                                                <!-- OSM-Link klein und rechtsbündig -->
-                                                <div class="text-end" style="width: 475px;">
-                                                  <a class="small d-block mt-1" target="_blank">
-                                                  <xsl:attribute name="href">
-                                                  <xsl:value-of select="$openstreetmapurl"/>
-                                                  </xsl:attribute>
-                                                  <i class="bi bi-box-arrow-up-right"/>
-                                                  OpenStreetMap </a>
-                                                </div>
-                                            </xsl:if>
+                                                  select="normalize-space(tei:title)"/>
+                                                </a>
+                                                <xsl:variable name="autoren"
+                                                  select="distinct-values(for $a in $workentry/tei:author return mam:vorname-nachname($a))"/>
+                                                <xsl:if
+                                                  test="$autoren[1] or normalize-space($workentry/tei:date[1])">
+                                                  <p class="work-meta">
+                                                  <xsl:value-of
+                                                  select="string-join($autoren, ', ')"/>
+                                                  <xsl:if
+                                                  test="$autoren[1] and normalize-space($workentry/tei:date[1])">
+                                                  <xsl:text> · </xsl:text>
+                                                  </xsl:if>
+                                                  <xsl:value-of
+                                                  select="normalize-space($workentry/tei:date[1])"
+                                                  />
+                                                  </p>
+                                                </xsl:if>
+                                            </div>
+                                            <a class="work-link"
+                                                href="{concat($workkey, '.html')}"
+                                                >Werkseite →</a>
                                         </li>
                                     </xsl:for-each>
-                                </ul>
-                            </td>
-                        </tr>
-                        <xsl:if
-                            test="tei:listBibl/tei:bibl/tei:title[not(tei:note[contains(., 'rezensi')])]">
-                            <tr>
-                                <th>Aufgeführte Werke</th>
-                                <td>
-                                    <ul>
-                                        <xsl:for-each
-                                            select="tei:listBibl/tei:bibl[not(tei:note[contains(., 'rezensi')]) and normalize-space(tei:title)]">
-                                            <li>
-                                                <xsl:element name="a">
-                                                  <xsl:attribute name="href">
-                                                  <xsl:value-of
-                                                  select="concat(tei:title/@key, '.html')"/>
-                                                  </xsl:attribute>
-                                                  <xsl:value-of select="normalize-space(tei:title)"
-                                                  />
-                                                </xsl:element>
-                                            </li>
-                                        </xsl:for-each>
-                                    </ul>
-                                </td>
-                            </tr>
+                                </ol>
+                            </section>
                         </xsl:if>
-                        <xsl:if
-                            test="tei:listBibl/tei:bibl/tei:title[(tei:note[contains(., 'rezensi')])]">
-                            <tr>
-                                <th>Rezensionen</th>
-                                <td>
-                                    <ul>
-                                        <xsl:for-each
-                                            select="tei:listBibl/tei:bibl[(tei:note[contains(., 'rezensi')]) and normalize-space(tei:title)]">
-                                            <li>
-                                                <xsl:element name="a">
-                                                  <xsl:attribute name="href">
+
+                        <!-- Rezensionen -->
+                        <xsl:variable name="rezensionen"
+                            select="tei:listBibl/tei:bibl[tei:note[contains(., 'rezensi')] and normalize-space(tei:title)]"/>
+                        <xsl:if test="$rezensionen">
+                            <section class="event-section">
+                                <h2 class="event-section-title">Rezensionen</h2>
+                                <ol class="work-list">
+                                    <xsl:for-each select="$rezensionen">
+                                        <li class="work-item">
+                                            <span class="work-num">
+                                                <xsl:value-of select="position()"/>
+                                            </span>
+                                            <div class="work-info">
+                                                <a class="work-title"
+                                                  href="{concat(tei:title/@key, '.html')}">
                                                   <xsl:value-of
-                                                  select="concat(tei:title/@key, '.html')"/>
-                                                  </xsl:attribute>
-                                                  <xsl:value-of select="normalize-space(tei:title)"
-                                                  />
-                                                </xsl:element>
-                                            </li>
-                                        </xsl:for-each>
-                                    </ul>
-                                </td>
-                            </tr>
+                                                  select="normalize-space(tei:title)"/>
+                                                </a>
+                                            </div>
+                                            <a class="work-link"
+                                                href="{concat(tei:title/@key, '.html')}"
+                                                >Werkseite →</a>
+                                        </li>
+                                    </xsl:for-each>
+                                </ol>
+                            </section>
                         </xsl:if>
-                        <xsl:if test="tei:listPerson/tei:person[@role = 'hat als Arbeitskraft' or contains(@role, 'mitwirkend')]">
-                            <tr>
-                                <th>Mitwirkende</th>
-                                <td>
-                                    <ul>
-                                        <xsl:for-each
-                                            select="tei:listPerson/tei:person[@role = 'hat als Arbeitskraft' or contains(@role, 'mitwirkend')]">
-                                            <li>
-                                                <xsl:variable name="name" select="tei:persName"/>
+
+                        <!-- Mitwirkende -->
+                        <xsl:variable name="mitwirkende"
+                            select="tei:listPerson/tei:person[@role = 'hat als Arbeitskraft' or contains(@role, 'mitwirkend')]"/>
+                        <xsl:if test="$mitwirkende">
+                            <section class="event-section">
+                                <h2 class="event-section-title">Mitwirkende</h2>
+                                <div class="person-chips">
+                                    <xsl:for-each select="$mitwirkende">
+                                        <xsl:call-template name="person-chip"/>
+                                    </xsl:for-each>
+                                </div>
+                            </section>
+                        </xsl:if>
+
+                        <!-- Teilnehmende -->
+                        <xsl:variable name="teilnehmende"
+                            select="tei:listPerson/tei:person[@role = 'hat als Teilnehmer:in' or contains(@role, 'teilnehmend')]"/>
+                        <xsl:if test="$teilnehmende">
+                            <section class="event-section">
+                                <h2 class="event-section-title">Teilnehmende</h2>
+                                <div class="person-chips">
+                                    <xsl:for-each select="$teilnehmende">
+                                        <xsl:call-template name="person-chip"/>
+                                    </xsl:for-each>
+                                </div>
+                            </section>
+                        </xsl:if>
+
+                        <!-- Beteiligte Institutionen -->
+                        <xsl:if test="tei:note[@type = 'listorg']/tei:listOrg/tei:org">
+                            <section class="event-section">
+                                <h2 class="event-section-title">Beteiligte Institutionen</h2>
+                                <div class="person-chips">
+                                    <xsl:for-each
+                                        select="tei:note[@type = 'listorg']/tei:listOrg/tei:org">
+                                        <a class="person-chip"
+                                            href="{concat(tei:orgName/@key, '.html')}">
+                                            <span class="chip-avatar" aria-hidden="true">
+                                                <xsl:value-of
+                                                  select="upper-case(substring(normalize-space(tei:orgName), 1, 1))"
+                                                />
+                                            </span>
+                                            <span class="chip-body">
+                                                <span class="chip-name">
+                                                  <xsl:value-of
+                                                  select="normalize-space(tei:orgName)"/>
+                                                </span>
+                                                <span class="chip-role">Institution</span>
+                                            </span>
+                                        </a>
+                                    </xsl:for-each>
+                                </div>
+                            </section>
+                        </xsl:if>
+
+                        <!-- Zeitgenössische Tageszeitungen -->
+                        <xsl:if test="@when-iso">
+                            <section class="event-section">
+                                <h2 class="event-section-title">Zeitgenössische
+                                    Tageszeitungen</h2>
+                                <div class="newspaper-cards">
+                                    <a class="newspaper-card" target="_blank">
+                                        <xsl:attribute name="href">
+                                            <xsl:value-of
+                                                select="concat('https://anno.onb.ac.at/cgi-content/anno?datum=', replace(@when-iso, '-', ''))"
+                                            />
+                                        </xsl:attribute>
+                                        <span class="newspaper-card-title">ANNO –
+                                            Österreich</span>
+                                        <span class="newspaper-card-sub">
+                                            <xsl:text>Zeitungen vom </xsl:text>
+                                            <xsl:value-of
+                                                select="format-date(@when-iso, '[D01].[M01].[Y]')"/>
+                                            <xsl:text> ↗</xsl:text>
+                                        </span>
+                                    </a>
+                                    <a class="newspaper-card" target="_blank">
+                                        <xsl:attribute name="href">
+                                            <xsl:value-of
+                                                select="concat('https://www.deutsche-digitale-bibliothek.de/newspaper/select/month?day=', day-from-date(@when-iso), '&amp;month=', month-from-date(@when-iso), '&amp;year=', year-from-date(@when-iso))"
+                                            />
+                                        </xsl:attribute>
+                                        <span class="newspaper-card-title">DDB –
+                                            Deutschland</span>
+                                        <span class="newspaper-card-sub">
+                                            <xsl:text>Zeitungen vom </xsl:text>
+                                            <xsl:value-of
+                                                select="format-date(@when-iso, '[D01].[M01].[Y]')"/>
+                                            <xsl:text> ↗</xsl:text>
+                                        </span>
+                                    </a>
+                                    <!-- Theaterzettel für Burgtheater/Hofoper -->
+                                    <xsl:if
+                                        test="(descendant::tei:placeName/@key = 'pmb14' or descendant::tei:placeName/@key = 'pmb185621') and not(contains(tei:eventName/@n, 'robe'))">
+                                        <a class="newspaper-card" target="_blank">
+                                            <xsl:attribute name="href">
                                                 <xsl:choose>
-                                                  <!-- Wenn genau ein Komma enthalten ist -->
                                                   <xsl:when
-                                                  test="matches($name, '^[^,]+,\s*[^,]+$')">
-                                                  <xsl:element name="a">
-                                                  <xsl:attribute name="href">
-                                                  <xsl:value-of select="concat($name/@key, '.html')"
+                                                  test="year-from-date(@when-iso) &lt; 1899">
+                                                  <xsl:value-of
+                                                  select="concat('https://anno.onb.ac.at/cgi-content/anno?aid=wtz&amp;datum=', replace(@when-iso, '-', ''))"
                                                   />
-                                                  </xsl:attribute>
-                                                  <xsl:analyze-string select="$name"
-                                                  regex="^([^,]+),\s*(.+)$">
-                                                  <xsl:matching-substring>
-                                                  <xsl:value-of select="regex-group(2)"/>
-                                                  <xsl:text> </xsl:text>
-                                                  <xsl:value-of select="regex-group(1)"/>
-                                                  </xsl:matching-substring>
-                                                  <xsl:non-matching-substring>
-                                                  <xsl:value-of select="."/>
-                                                  </xsl:non-matching-substring>
-                                                  </xsl:analyze-string>
-                                                  </xsl:element>
                                                   </xsl:when>
-                                                  <!-- Wenn kein oder mehr als ein Komma enthalten ist -->
                                                   <xsl:otherwise>
-                                                  <xsl:element name="a">
-                                                  <xsl:attribute name="href">
-                                                  <xsl:value-of select="concat($name/@key, '.html')"
+                                                  <xsl:value-of
+                                                  select="concat('https://anno.onb.ac.at/cgi-content/anno?aid=bth&amp;datum=', replace(@when-iso, '-', ''))"
                                                   />
-                                                  </xsl:attribute>
-                                                  <xsl:value-of select="$name"/>
-                                                  </xsl:element>
                                                   </xsl:otherwise>
                                                 </xsl:choose>
-                                            </li>
-                                        </xsl:for-each>
-                                    </ul>
-                                </td>
-                            </tr>
+                                            </xsl:attribute>
+                                            <span class="newspaper-card-title">Theaterzettel</span>
+                                            <span class="newspaper-card-sub">
+                                                <xsl:text>ANNO, </xsl:text>
+                                                <xsl:value-of
+                                                  select="format-date(@when-iso, '[D01].[M01].[Y]')"/>
+                                                <xsl:text> ↗</xsl:text>
+                                            </span>
+                                        </a>
+                                    </xsl:if>
+                                </div>
+                            </section>
                         </xsl:if>
-                        <tr>
-                            <th>Teilnehmende</th>
-                            <td>
-                                <ul>
+                    </div>
+
+                    <aside class="event-side">
+
+                        <!-- Ort -->
+                        <xsl:variable name="erster-ort"
+                            select="tei:listPlace/tei:place[normalize-space(tei:placeName)][1]"/>
+                        <xsl:if test="$erster-ort">
+                            <div class="side-card">
+                                <xsl:if test="$erster-ort/tei:location/tei:geo">
+                                    <div id="map_detail" class="side-card-map"/>
+                                </xsl:if>
+                                <div class="side-card-body">
+                                    <h2 class="side-card-title">
+                                        <xsl:value-of
+                                            select="normalize-space($erster-ort/tei:placeName)"/>
+                                    </h2>
                                     <xsl:for-each
-                                        select="tei:listPerson/tei:person[@role = 'hat als Teilnehmer:in' or contains(@role, 'teilnehmend')]">
-                                        <li>
-                                            <xsl:variable name="name" select="tei:persName"/>
-                                            <xsl:choose>
-                                                <!-- Wenn genau ein Komma enthalten ist -->
-                                                <xsl:when test="matches($name, '^[^,]+,\s*[^,]+$')">
-                                                  <xsl:element name="a">
-                                                  <xsl:attribute name="href">
-                                                  <xsl:value-of select="concat($name/@key, '.html')"
-                                                  />
-                                                  </xsl:attribute>
-                                                  <xsl:analyze-string select="$name"
-                                                  regex="^([^,]+),\s*(.+)$">
-                                                  <xsl:matching-substring>
-                                                  <xsl:value-of select="regex-group(2)"/>
-                                                  <xsl:text> </xsl:text>
-                                                  <xsl:value-of select="regex-group(1)"/>
-                                                  </xsl:matching-substring>
-                                                  <xsl:non-matching-substring>
-                                                  <xsl:value-of select="."/>
-                                                  </xsl:non-matching-substring>
-                                                  </xsl:analyze-string>
-                                                  </xsl:element>
-                                                </xsl:when>
-                                                <!-- Wenn kein oder mehr als ein Komma enthalten ist -->
-                                                <xsl:otherwise>
-                                                  <xsl:element name="a">
-                                                  <xsl:attribute name="href">
-                                                  <xsl:value-of select="concat($name/@key, '.html')"
-                                                  />
-                                                  </xsl:attribute>
-                                                  <xsl:value-of select="$name"/>
-                                                  </xsl:element>
-                                                </xsl:otherwise>
-                                            </xsl:choose>
-                                        </li>
+                                        select="tei:listPlace/tei:place[normalize-space(tei:placeName)][position() &gt; 1]">
+                                        <p class="side-card-sub">
+                                            <xsl:value-of
+                                                select="normalize-space(tei:placeName)"/>
+                                        </p>
                                     </xsl:for-each>
-                                </ul>
-                            </td>
-                        </tr>
-                        <xsl:if test="descendant::tei:listOrg">
-                            <tr>
-                                <th>Beteiligte Institution</th>
-                                <td>
-                                    <ul>
-                                        <xsl:for-each
-                                            select="tei:note[@type = 'listorg']/tei:listOrg/tei:org">
-                                            <li>
-                                                <xsl:element name="a">
-                                                  <xsl:attribute name="href">
-                                                  <xsl:value-of
-                                                  select="concat(tei:orgName/@key, '.html')"/>
-                                                  </xsl:attribute>
-                                                  <xsl:value-of select="tei:orgName"/>
-                                                </xsl:element>
-                                            </li>
-                                        </xsl:for-each>
-                                    </ul>
-                                </td>
-                            </tr>
+                                    <p class="side-card-links">
+                                        <a href="{concat($erster-ort/tei:placeName/@key, '.html')}"
+                                            >Ortsseite →</a>
+                                        <xsl:if test="$erster-ort/tei:location/tei:geo">
+                                            <xsl:variable name="mlat"
+                                                select="replace(tokenize($erster-ort/tei:location[1]/tei:geo[1], '\s')[1], ',', '.')"/>
+                                            <xsl:variable name="mlong"
+                                                select="replace(tokenize($erster-ort/tei:location[1]/tei:geo[1], '\s')[2], ',', '.')"/>
+                                            <a target="_blank"
+                                                href="{concat('https://www.openstreetmap.org/?mlat=', $mlat, '&amp;mlon=', $mlong, '#map=15/', $mlat, '/', $mlong)}"
+                                                >OpenStreetMap ↗</a>
+                                        </xsl:if>
+                                    </p>
+                                </div>
+                            </div>
                         </xsl:if>
-                        <xsl:if test="(descendant::tei:placeName/@key = 'pmb14' or descendant::tei:placeName/@key = 'pmb185621') and not(contains(tei:eventName/@n, 'robe'))">
-                            <tr>
-                                <th>Theaterzettel</th>
-                                <td>
-                                    <ul>
+
+                        <!-- Datensatz -->
+                        <div class="side-card">
+                            <div class="side-card-body">
+                                <h2 class="side-card-title side-card-title-small">Datensatz</h2>
+                                <ul class="record-list">
+                                    <xsl:for-each
+                                        select="tei:idno[@subtype = 'pmb' and normalize-space(.)]">
                                         <li>
-                                            <a>
-                                                <xsl:attribute name="target">
-                                                  <xsl:text>_blank</xsl:text>
-                                                </xsl:attribute>
-                                                <xsl:attribute name="href">
-                                                    <xsl:choose>
-                                                        <xsl:when test="year-from-date(@when-iso) &lt; 1899">
-                                                            <xsl:value-of
-                                                                select="concat('https://anno.onb.ac.at/cgi-content/anno?aid=wtz&amp;datum=', replace(@when-iso, '-', ''))"
-                                                            />
-                                                        </xsl:when>
-                                                        <xsl:otherwise>
-                                                            <xsl:value-of
-                                                                select="concat('https://anno.onb.ac.at/cgi-content/anno?aid=bth&amp;datum=', replace(@when-iso, '-', ''))"
-                                                            />
-                                                        </xsl:otherwise>
-                                                    </xsl:choose>
-                                                    
-                                                </xsl:attribute>
-                                                <xsl:text>ANNO</xsl:text>
+                                            <span class="record-label">PMB</span>
+                                            <a target="_blank" href="{normalize-space(.)}">
+                                                <xsl:value-of
+                                                  select="concat('Eintrag ', substring-after(ancestor::tei:event/@xml:id, 'pmb'), ' ↗')"
+                                                />
                                             </a>
                                         </li>
-                                    </ul>
-                                </td>
-                            </tr>
-                        </xsl:if>
-                        <tr>
-                            <th>Tageszeitungen</th>
-                            <td>
-                                <ul>
-                                    <li>
-                                        <a>
-                                            <xsl:attribute name="target">
-                                                <xsl:text>_blank</xsl:text>
-                                            </xsl:attribute>
-                                            <xsl:attribute name="href">
+                                    </xsl:for-each>
+                                    <xsl:if test="@when-iso">
+                                        <li>
+                                            <span class="record-label">Chronik</span>
+                                            <a target="_blank"
+                                                href="{concat('https://schnitzler-chronik.acdh.oeaw.ac.at/', @when-iso, '.html')}">
                                                 <xsl:value-of
-                                                    select="concat('https://anno.onb.ac.at/cgi-content/anno?datum=', replace(@when-iso, '-', ''))"
-                                                />
-                                            </xsl:attribute>
-                                            <xsl:text>Österreich</xsl:text>
-                                        </a>
-                                    </li>
+                                                  select="concat(@when-iso, ' ↗')"/>
+                                            </a>
+                                        </li>
+                                    </xsl:if>
                                     <li>
-                                        <a>
-                                            <xsl:attribute name="target">
-                                                <xsl:text>_blank</xsl:text>
-                                            </xsl:attribute>
-                                            <xsl:attribute name="href">
-                                                <xsl:value-of
-                                                    select="concat('https://www.deutsche-digitale-bibliothek.de/newspaper/select/month?day=', day-from-date(@when-iso), '&amp;month=', month-from-date(@when-iso), '&amp;year=', year-from-date(@when-iso))"
-                                                />
-                                            </xsl:attribute>
-                                            <xsl:text>Deutschland</xsl:text>
-                                        </a>
+                                        <span class="record-label">XML/TEI</span>
+                                        <a href="listevent.xml">Quelldaten ↓</a>
                                     </li>
                                 </ul>
-                                
-                            </td>
-                            
-                            
-                        </tr>
-                    </tbody>
-                </table>
+                                <button type="button" class="btn copy-citation">
+                                    <xsl:attribute name="data-citation">
+                                        <xsl:value-of select="normalize-space(tei:eventName[1])"/>
+                                        <xsl:text>. In: Arthur Schnitzler: Kulturveranstaltungen. Konzert-, Theater-, Kinobesuche, Lesungen, Proben- und weitere Veranstaltungsteilnahmen. 1876–1931. Hg. von Martin Anton Müller und Laura Untner. https://schnitzler-kultur.acdh.oeaw.ac.at/</xsl:text>
+                                        <xsl:value-of select="$selfLink"/>
+                                        <xsl:text> (Abfrage {DATUM})</xsl:text>
+                                    </xsl:attribute>
+                                    <xsl:text>Zitiervorschlag kopieren</xsl:text>
+                                </button>
+                            </div>
+                        </div>
+
+                        <!-- Kontext -->
+                        <xsl:if test="$erster-ort">
+                            <xsl:variable name="placekey"
+                                select="$erster-ort/tei:placeName/@key"/>
+                            <xsl:variable name="weitere"
+                                select="count(key('events-by-place', $placekey)) - 1"/>
+                            <xsl:if test="$weitere &gt; 0">
+                                <div class="side-card side-card-context">
+                                    <div class="side-card-body">
+                                        <h2 class="side-card-title side-card-title-small">
+                                            <xsl:value-of
+                                                select="concat('Im ', normalize-space($erster-ort/tei:placeName))"
+                                            />
+                                        </h2>
+                                        <p class="side-card-context-text">
+                                            <xsl:text>Schnitzler besuchte </xsl:text>
+                                            <xsl:value-of select="$weitere"/>
+                                            <xsl:choose>
+                                                <xsl:when test="$weitere = 1">
+                                                  <xsl:text> weitere Veranstaltung</xsl:text>
+                                                </xsl:when>
+                                                <xsl:otherwise>
+                                                  <xsl:text> weitere Veranstaltungen</xsl:text>
+                                                </xsl:otherwise>
+                                            </xsl:choose>
+                                            <xsl:text> an diesem Ort.</xsl:text>
+                                        </p>
+                                        <p class="side-card-links">
+                                            <a href="{concat($placekey, '.html')}">Alle
+                                                Veranstaltungen hier →</a>
+                                        </p>
+                                    </div>
+                                </div>
+                            </xsl:if>
+                        </xsl:if>
+                    </aside>
+                </div>
             </div>
         </div>
     </xsl:template>
-    
+
+    <!-- Personen-Chip mit Initialen-Avatar, Name und Rolle -->
+    <xsl:template name="person-chip">
+        <xsl:variable name="name" select="tei:persName"/>
+        <xsl:variable name="anzeigename">
+            <xsl:choose>
+                <xsl:when test="matches($name, '^[^,]+,\s*[^,]+$')">
+                    <xsl:value-of
+                        select="concat(normalize-space(substring-after($name, ',')), ' ', normalize-space(substring-before($name, ',')))"
+                    />
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="normalize-space($name)"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:variable name="initialen">
+            <xsl:choose>
+                <xsl:when test="matches($name, '^[^,]+,\s*[^,]+$')">
+                    <xsl:value-of
+                        select="upper-case(concat(substring(normalize-space(substring-after($name, ',')), 1, 1), substring(normalize-space(substring-before($name, ',')), 1, 1)))"
+                    />
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="upper-case(substring(normalize-space($name), 1, 1))"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:variable name="rolle">
+            <xsl:choose>
+                <xsl:when test="@role = 'hat als Arbeitskraft'">Arbeitskraft</xsl:when>
+                <xsl:when test="contains(@role, 'mitwirkend')">Mitwirkung</xsl:when>
+                <xsl:otherwise>Teilnahme</xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <a class="person-chip" href="{concat($name/@key, '.html')}">
+            <span class="chip-avatar" aria-hidden="true">
+                <xsl:value-of select="$initialen"/>
+            </span>
+            <span class="chip-body">
+                <span class="chip-name">
+                    <xsl:value-of select="$anzeigename"/>
+                </span>
+                <span class="chip-role">
+                    <xsl:value-of select="$rolle"/>
+                </span>
+            </span>
+        </a>
+    </xsl:template>
+
+    <xsl:function name="mam:vorname-nachname" as="xs:string">
+        <xsl:param name="name"/>
+        <xsl:choose>
+            <xsl:when test="matches($name, '^[^,]+,\s*[^,]+$')">
+                <xsl:value-of
+                    select="concat(normalize-space(substring-after($name, ',')), ' ', normalize-space(substring-before($name, ',')))"
+                />
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="normalize-space($name)"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+
     <xsl:function name="mam:wochentag" as="xs:string">
         <xsl:param name="iso-datum" as="xs:date"/>
         <xsl:variable name="day-of-the-week" as="xs:string" select="format-date($iso-datum, '[F]')"/>

--- a/xslt/partials/html_footer.xsl
+++ b/xslt/partials/html_footer.xsl
@@ -1,66 +1,58 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns="http://www.w3.org/1999/xhtml"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    exclude-result-prefixes="#all" version="2.0">
+    xmlns:tei="http://www.tei-c.org/ns/1.0" exclude-result-prefixes="#all" version="2.0">
     <xsl:template match="/" name="html_footer">
-        <div class="wrapper hide-reading mt-5" id="wrapper-footer-full">
-            <div class="container" id="footer-full-content" tabindex="-1">
-                <div class="row justify-content-between align-items-start">
-                    <!-- Linke Spalte: Logo + Institut -->
-                    <div class="footer-widget col-lg-6 col-md-6 mb-4">
-                        <div class="textwidget custom-html-widget d-flex">
-                            <div style="margin: 20px">
-                                <a href="https://www.oeaw.ac.at/acdh/">
-                                    <img src="https://fundament.acdh.oeaw.ac.at/common-assets/images/acdh_logo.svg"
-                                        alt="ACDH Logo" title="ACDH Logo"
-                                        style="max-width: 100px; height: auto;" />
-                                </a>
-                            </div>
-                            <div>
-                                <p>
-                                    <strong>ACDH</strong><br/>
-                                    Austrian Centre for Digital Humanities<br/>
-                                    Österreichische Akademie der Wissenschaften<br/>
-                                    Bäckerstraße 13<br/>
-                                    1010 Wien<br/>
-                                    T: +43 1 51581-2200<br/>
-                                    E: <a href="mailto:acdh-helpdesk@oeaw.ac.at">acdh-helpdesk(at)oeaw.ac.at</a>
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                    
-                    <!-- Rechte Spalte: Kontaktperson + GitHub -->
-                    <div class="footer-widget col-lg-6 col-md-6 mb-4">
-                        <div class="textwidget custom-html-widget">
-                            <h6 class="font-weight-bold">KONTAKT</h6>
-                            <p>Bei Fragen, Anmerkungen, Kritik oder Lob kontaktieren<br/>
-                                Sie bitte Martin Anton Müller oder Laura Untner:</p>
-                            <p>
-                                <a class="helpdesk-button" href="mailto:martin.anton.mueller@encore.at">e-Mail</a>
-                            </p>
-                            <p>
-                                <a id="github-logo" title="GitHub" href="{$github_url}" target="_blank">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24">
-                                        <path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-4.466 19.59c-.405.078-.534-.171-.534-.384v-2.195c0-.747-.262-1.233-.55-1.481 1.782-.198 3.654-.875 3.654-3.947 0-.874-.312-1.588-.823-2.147.082-.202.356-1.016-.079-2.117 0 0-.671-.215-2.198.82-.64-.18-1.324-.267-2.004-.271-.68.003-1.364.091-2.003.269-1.528-1.035-2.2-.82-2.2-.82-.434 1.102-.16 1.915-.077 2.118-.512.56-.824 1.273-.824 2.147 0 3.064 1.867 3.751 3.645 3.954-.229.2-.436.552-.508 1.07-.457.204-1.614.557-2.328-.666 0 0-.423-.768-1.227-.825 0 0-.78-.01-.055.487 0 0 .525.246.889 1.17 0 0 .463 1.428 2.688.944v1.489c0 .211-.129.459-.528.385-3.18-1.057-5.472-4.056-5.472-7.59 0-4.419 3.582-8 8-8s8 3.581 8 8c0 3.533-2.289 6.531-5.466 7.59z"/>
-                                    </svg>
-                                </a>
-                            </p>
-                        </div>
-                    </div>
+        <xsl:variable name="footer-eventcount"
+            select="count(document('../../data/editions/listevent.xml')//tei:body/tei:listEvent/tei:event)"/>
+        <footer class="site-footer hide-reading">
+            <div class="site-footer-inner">
+                <div class="site-footer-col">
+                    <p class="site-footer-title">Arthur Schnitzler:
+                        Kulturveranstaltungen</p>
+                    <p>
+                        <xsl:value-of
+                            select="format-number($footer-eventcount, '#.###', 'footer-european')"/>
+                        <xsl:text> Ereignisse aus den Jahren 1876–1931: Konzert-, Theater- und
+                            Kinobesuche, Lesungen, Proben und weitere
+                            Veranstaltungsteilnahmen.</xsl:text>
+                    </p>
+                    <p>Herausgegeben von Martin Anton Müller und Laura Untner, unter
+                        Mitarbeit von Katharina Sophie Kühnel.</p>
+                </div>
+                <div class="site-footer-col">
+                    <p class="site-footer-title">ACDH-CH</p>
+                    <p>Austrian Centre for Digital Humanities and Cultural
+                        Heritage<br/>Österreichische Akademie der
+                        Wissenschaften<br/>Bäckerstraße 13<br/>1010 Wien</p>
+                    <p>T: +43 1 51581-2200<br/>E: <a
+                            href="mailto:acdh-helpdesk@oeaw.ac.at"
+                            >acdh-helpdesk(at)oeaw.ac.at</a></p>
+                </div>
+                <div class="site-footer-col">
+                    <p class="site-footer-title">Kontakt</p>
+                    <ul class="site-footer-links">
+                        <li>
+                            <a href="mailto:martin.anton.mueller@encore.at">E-Mail an die
+                                Herausgeber</a>
+                        </li>
+                        <li>
+                            <a href="{$github_url}" target="_blank">GitHub</a>
+                        </li>
+                        <li>
+                            <a href="imprint.html">Impressum</a>
+                        </li>
+                    </ul>
                 </div>
             </div>
-        </div>
-        
-        <!-- Footer Bar -->
-        <div class="footer-imprint-bar hide-reading" id="wrapper-footer-secondary"
-            style="text-align:center; padding:0.4rem 0; font-size: 0.9rem; background-color: white;">
-            © Copyright OEAW | <a href="imprint.html">Impressum</a>
-        </div>
+            <div class="site-footer-bar">
+                <xsl:text>© ÖAW · CC BY 4.0</xsl:text>
+            </div>
+        </footer>
         <script src="js/listStopProp.js"/>
         <script src="https://code.jquery.com/jquery-3.6.3.min.js"
             integrity="sha256-pvPw+upLPUjgMXY0G+8O0xUf+/Im1MZjXxxgOcBQBXU=" crossorigin="anonymous"/>
     </xsl:template>
-    
-    
+
+    <xsl:decimal-format name="footer-european" grouping-separator="." decimal-separator=","/>
 </xsl:stylesheet>

--- a/xslt/partials/html_head.xsl
+++ b/xslt/partials/html_head.xsl
@@ -51,6 +51,10 @@
         <link rel="stylesheet" href="css/style.css" type="text/css"/>
         <link rel="stylesheet" href="css/entities.css" type="text/css"/>
         <link rel="stylesheet" href="css/micro-editor.css" type="text/css"/>
+        <link rel="preconnect" href="https://fonts.googleapis.com"/>
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous"/>
+        <link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,400;0,600;0,700;1,400;1,600&amp;display=swap" rel="stylesheet"/>
+        <link rel="stylesheet" href="css/theme.css" type="text/css"/>
         <link rel="apple-touch-icon" sizes="180x180" href="images/apple-touch-icon-180x180.png"/>
         <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png"/>
         <link rel="icon" type="image/png" sizes="16x16" href="images/favicon-16x16.png"/>

--- a/xslt/partials/html_navbar.xsl
+++ b/xslt/partials/html_navbar.xsl
@@ -4,7 +4,7 @@
     xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="#all" version="2.0">
     <xsl:template match="/" name="nav_bar">
         <header class="site-header">
-            <nav aria-label="Primary" class="navbar navbar-expand-lg site-nav">
+            <nav aria-label="Primary" class="navbar navbar-expand-md site-nav">
                 <div class="container-fluid site-nav-inner">
                     <a href="index.html" class="navbar-brand brand-wordmark" rel="home">
                         <span class="brand-name">Schnitzler</span>
@@ -17,7 +17,7 @@
                         <span class="navbar-toggler-icon"/>
                     </button>
                     <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                        <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
+                        <ul class="navbar-nav ms-auto mb-2 mb-md-0 align-items-md-center">
                             <li class="nav-item">
                                 <a class="nav-link" href="listevent.html">Veranstaltungen</a>
                             </li>
@@ -134,7 +134,7 @@
                             <li class="nav-item dropdown">
                                 <a class="nav-link dropdown-toggle" href="#" role="button"
                                     data-bs-toggle="dropdown" aria-expanded="false">Projekt</a>
-                                <ul class="dropdown-menu dropdown-menu-lg-end">
+                                <ul class="dropdown-menu dropdown-menu-md-end">
                                     <li>
                                         <a class="dropdown-item" href="ueber-das-projekt.html">Über das
                                             Projekt</a>

--- a/xslt/partials/html_navbar.xsl
+++ b/xslt/partials/html_navbar.xsl
@@ -3,13 +3,12 @@
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:tei="http://www.tei-c.org/ns/1.0"
     xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="#all" version="2.0">
     <xsl:template match="/" name="nav_bar">
-        <header>
-            <nav aria-label="Primary" class="navbar navbar-expand-lg bg-body-tertiary">
-                <div class="container-fluid">
-                    <a href="index.html" class="navbar-brand custom-logo-link" rel="home"
-                        itemprop="url">
-                        <img src="./images/schnitzler-kultur.svg" class="img-fluid"
-                            title="schnitzler-kultur" alt="schnitzler-kultur" itemprop="logo"/>
+        <header class="site-header">
+            <nav aria-label="Primary" class="navbar navbar-expand-lg site-nav">
+                <div class="container-fluid site-nav-inner">
+                    <a href="index.html" class="navbar-brand brand-wordmark" rel="home">
+                        <span class="brand-name">Schnitzler</span>
+                        <span class="brand-sub">Kulturveranstaltungen</span>
                     </a>
                     <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
                         data-bs-target="#navbarSupportedContent"
@@ -18,28 +17,7 @@
                         <span class="navbar-toggler-icon"/>
                     </button>
                     <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-                            <li class="nav-item dropdown">
-                                <a class="nav-link dropdown-toggle" href="#" role="button"
-                                    data-bs-toggle="dropdown" aria-expanded="false">Projekt</a>
-                                <ul class="dropdown-menu">
-                                    <li>
-                                        <a class="dropdown-item" href="ueber-das-projekt.html">Über das
-                                            Projekt</a>
-                                    </li>
-                                    <li>
-                                        <a class="dropdown-item" href="faqs.html">Häufig gestellte Fragen</a>
-                                    </li>
-                                    <li>
-                                        <a class="dropdown-item"
-                                            href="https://schnitzler-mikrofilme.acdh.oeaw.ac.at/1428689.html"
-                                            target="_blank">A179 Theaterbesuche</a>
-                                    </li>
-                                    <li>
-                                        <a class="dropdown-item" href="imprint.html">Impressum</a>
-                                    </li>
-                                </ul>
-                            </li>
+                        <ul class="navbar-nav ms-auto mb-2 mb-lg-0 align-items-lg-center">
                             <li class="nav-item">
                                 <a class="nav-link" href="listevent.html">Veranstaltungen</a>
                             </li>
@@ -153,16 +131,34 @@
                                     </li>
                                 </ul>
                             </li>
-                            <!--  <li class="nav-item">
-                                <a title="Suche" class="nav-link" href="search.html"><svg
-                                        xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                        viewBox="0 0 24 24" fill="none" stroke="currentColor"
-                                        stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-                                        class="feather feather-search">
-                                        <circle cx="11" cy="11" r="8"/>
-                                        <line x1="21" y1="21" x2="16.65" y2="16.65"/>
-                                </svg> SUCHE</a>
-                            </li>-->
+                            <li class="nav-item dropdown">
+                                <a class="nav-link dropdown-toggle" href="#" role="button"
+                                    data-bs-toggle="dropdown" aria-expanded="false">Projekt</a>
+                                <ul class="dropdown-menu dropdown-menu-lg-end">
+                                    <li>
+                                        <a class="dropdown-item" href="ueber-das-projekt.html">Über das
+                                            Projekt</a>
+                                    </li>
+                                    <li>
+                                        <a class="dropdown-item" href="faqs.html">Häufig gestellte Fragen</a>
+                                    </li>
+                                    <li>
+                                        <a class="dropdown-item"
+                                            href="https://schnitzler-mikrofilme.acdh.oeaw.ac.at/1428689.html"
+                                            target="_blank">A179 Theaterbesuche</a>
+                                    </li>
+                                    <li>
+                                        <a class="dropdown-item" href="imprint.html">Impressum</a>
+                                    </li>
+                                </ul>
+                            </li>
+                            <li class="nav-item nav-item-search">
+                                <a class="search-pill" href="listevent.html"
+                                    title="Veranstaltungen durchsuchen und filtern">
+                                    <i class="bi bi-search" aria-hidden="true"/>
+                                    <span>Suche</span>
+                                </a>
+                            </li>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
## Zusammenfassung

Umsetzung des neuen Layouts gemäß der Anleitung „Umsetzung mit Claude Code", Etappen 1–6, mit einem Commit pro Etappe:

- **Design-Tokens + Basis-CSS** (`html/css/theme.css`): warmes Weiß `#FAF8F5`, Bordeaux-Akzent `#8A2E35`, Schrift „Source Sans 3", Links ohne Unterstreichung (Hover unterstrichen).
- **Neuer Header**: schlanke sticky Leiste (64 px), Wortmarke „Schnitzler KULTURVERANSTALTUNGEN" statt Logo, Navigation rechts, Such-Pill.
- **Ereigniskopf + Prev/Next**: chronologische Vorgänger-/Nachfolger-Navigation (48-px-Leiste), Kicker „{TYP} — PMB {ID}", großer Titel mit kursivem Werktitel, ausgeschriebenes Datum mit Chronik-/Tagebuch-Link.
- **Zweispaltige Ereignisseite** (Grid `1fr 380px`): Werkliste mit Autor/Jahr aus dem Werkverzeichnis, Personen-Chips mit Initialen-Avataren, ANNO-/DDB-Zeitungskarten; Seitenleiste mit Leaflet-Karte (Bordeaux-Marker), Datensatz-Karte inkl. „Zitiervorschlag kopieren" (`html/js/citation.js`) und Kontext-Karte („Im {Ort}: N weitere Veranstaltungen"). Leere Abschnitte entfallen vollständig.
- **Neuer Footer**: dunkel, 3 Spalten, dynamisch gezählte Ereigniszahl, Zeile „© ÖAW · CC BY 4.0".
- **Responsive + A11y**: unter 1000 px einspaltig und Prev/Next nur Pfeile + Datum, Burger-Menü unter 768 px, Fokusring in Akzentfarbe, Kontraste auf WCAG AA geprüft (kleine Beschriftungen auf `--ink-muted` angehoben).

## Bewusste Abweichungen von der Anleitung

- Der „Schnitzler"-Dropdown (Links zu Schwesterprojekten) bleibt erhalten, obwohl die Header-Spec ihn nicht nennt.
- Die Such-Pill verlinkt auf die filterbare Veranstaltungsliste, da `search.html` im Build deaktiviert ist.
- Kleine Versalien-Labels nutzen `--ink-muted` statt `--ink-faint` (2,9:1 → 5,5:1, WCAG AA).
- Zitationsformat neu definiert (es gab bisher keines).

## Test

- Referenzseite `pmb207360.html` nach jeder Etappe gebaut und bei 1440/900/375 px per Screenshot geprüft.
- Edge-Cases: 49 Teilnehmende (Chips skalieren), Ereignis ohne Ort (Karten entfallen), Ereignisse mit Zeitspannen.
- Zitier-Button funktional getestet („Zitation kopiert ✓", Text in Zwischenablage).
- Voller `ant`-Build erfolgreich; Overflow-Audit über 14 Seiten bei 375 px: kein horizontales Scrollen.

Etappe 7 (Ausrollen auf Listen-/Register-/Kalenderseiten) folgt nach Abnahme der Ereignisseite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)