### PR TITLE
Etappe 7: Neues Layout für Liste, Register, Kalender und Statistik

### DIFF
--- a/html/css/theme.css
+++ b/html/css/theme.css
@@ -6,7 +6,7 @@
 
 :root {
     /* Flächen */
-    --bg: #FAF8F5;            /* warmes Weiß */
+    --bg: #FFFFFF;            /* weiß */
     --surface: #FFFFFF;
     --surface-2: #F4F0EA;
 
@@ -116,32 +116,16 @@ a:focus {
     padding-right: 32px;
 }
 
-/* Wortmarke */
-.brand-wordmark {
-    display: flex;
-    align-items: baseline;
-    gap: 10px;
-    text-decoration: none;
+/* Logo (übersteuert die Altregel .navbar .navbar-brand img { height: 5rem }) */
+.site-header .navbar-brand {
+    padding: 6px 0;
 }
 
-.brand-name {
-    font-size: 22px;
-    font-weight: 600;
-    color: var(--ink);
-    line-height: 1;
-}
-
-.brand-sub {
-    font-size: 13px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.14em;
-    color: var(--accent);
-    line-height: 1;
-}
-
-.brand-wordmark:hover .brand-name {
-    color: var(--accent-dark);
+.site-header .navbar-brand img.site-logo {
+    height: 52px;
+    width: auto;
+    max-width: none;
+    max-height: none;
 }
 
 /* Navigationslinks */
@@ -173,27 +157,6 @@ a:focus {
     background-color: var(--surface-2);
 }
 
-/* Such-Pill */
-.search-pill {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    border: 1px solid var(--line);
-    border-radius: 999px;
-    padding: 6px 16px;
-    margin-left: 12px;
-    font-size: 14px;
-    color: var(--ink-muted);
-    background: var(--surface);
-}
-
-.search-pill:hover,
-.search-pill:focus {
-    color: var(--accent-dark);
-    border-color: var(--accent);
-    text-decoration: none;
-}
-
 /* Burger-Menü-Zustand (Bootstrap navbar-expand-md: unter 768 px) */
 @media (max-width: 767.98px) {
     .site-header .navbar {
@@ -205,22 +168,8 @@ a:focus {
         padding-right: 20px;
     }
 
-    .search-pill {
-        margin-left: 0;
-        margin-top: 8px;
-    }
-}
-
-@media (max-width: 575.98px) {
-    /* Wortmarke stapeln, damit der Menü-Button daneben Platz hat */
-    .brand-wordmark {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 3px;
-    }
-
-    .brand-sub {
-        font-size: 11px;
+    .site-header .navbar-brand img.site-logo {
+        height: 44px;
     }
 }
 
@@ -732,6 +681,134 @@ a:focus {
     .site-footer br {
         display: inline;
     }
+}
+
+/* =========================================================
+   Listen-, Register-, Kalender- und Statistikseiten
+   ========================================================= */
+
+/* Seitenkopf in der Formensprache der Ereignisseite */
+.page-head {
+    padding: 40px 0 20px;
+}
+
+.page-kicker {
+    font-size: 13px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--accent);
+    margin-bottom: 10px;
+}
+
+.page-head h1 {
+    font-size: 32px;
+    font-weight: 700;
+    line-height: 1.2;
+    text-align: left;
+    padding: 0;
+    margin: 0 0 8px;
+}
+
+.page-sub {
+    font-size: 16px;
+    color: var(--ink-muted);
+    margin: 0;
+}
+
+.page-sub a {
+    font-size: 15px;
+}
+
+.page-intro {
+    max-width: 800px;
+    color: var(--ink);
+    margin-bottom: 24px;
+}
+
+/* Tabulator-Tabellen als Karten */
+.tabulator {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+}
+
+.tabulator .tabulator-header,
+.tabulator .tabulator-header .tabulator-col {
+    background: var(--surface-2);
+}
+
+.tabulator .tabulator-header {
+    border-bottom: 1px solid var(--line);
+}
+
+/* Karte auf der Orte-Seite */
+div#map {
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    margin-bottom: 24px;
+    z-index: 0;
+}
+
+/* Download-Bereich unter den Tabellen */
+.dl-section {
+    margin: 28px 0 56px;
+}
+
+.dl-section .btn-outline-secondary {
+    border-color: var(--line);
+    color: var(--ink-muted);
+    border-radius: 6px;
+    font-size: 14px;
+}
+
+.dl-section .btn-outline-secondary:hover,
+.dl-section .btn-outline-secondary:focus {
+    background: var(--surface-2);
+    border-color: var(--accent);
+    color: var(--accent-dark);
+}
+
+/* Formularelemente: Akzent statt Bootstrap-Blau */
+.form-check-input:checked {
+    background-color: var(--accent);
+    border-color: var(--accent);
+}
+
+.btn-check:checked + .btn-outline-secondary {
+    background-color: var(--accent);
+    border-color: var(--accent);
+    color: #fff;
+}
+
+/* Bootstrap-Karten (z. B. Statistik) – Startseiten-Kacheln ausgenommen */
+.card:not(.index-card) {
+    border: 1px solid var(--line);
+    border-radius: 8px;
+}
+
+.card:not(.index-card) .card-header {
+    background: var(--surface-2);
+    border-bottom: 1px solid var(--line);
+}
+
+/* Startseiten-Hero: Unterkante in Akzentfarbe statt Alt-Mauve */
+.intro {
+    border-bottom-color: var(--accent);
+}
+
+/* Buttons der Startseite */
+.btn-round {
+    background-color: var(--accent);
+    color: #fff;
+    border: 1px solid var(--accent);
+}
+
+.btn-round:hover,
+.btn-round:focus {
+    background-color: var(--accent-dark);
+    border-color: var(--accent-dark);
+    color: #fff;
 }
 
 /* ------- Responsiv ------- */

--- a/html/js/calendar-init.js
+++ b/html/js/calendar-init.js
@@ -284,11 +284,11 @@ optimizedStyles.textContent = `
     
     .yearbtn:hover {
         background: #f8f9fa;
-        color: #007bff;
+        color: var(--accent, #8A2E35);
     }
     
     .yearbtn.focus {
-        background: #007bff;
+        background: var(--accent, #8A2E35);
         color: white;
         font-weight: 600;
     }

--- a/html/js/calendar.js
+++ b/html/js/calendar.js
@@ -245,14 +245,14 @@ class SimpleCalendar {
         }
         
         .nav-btn.today {
-          background: #007bff;
-          border-color: #007bff;
+          background: var(--accent, #8A2E35);
+          border-color: var(--accent, #8A2E35);
           color: white;
         }
         
         .nav-btn.today:hover {
-          background: #0056b3;
-          border-color: #0056b3;
+          background: var(--accent-dark, #5E1F24);
+          border-color: var(--accent-dark, #5E1F24);
         }
         
         .period-title {
@@ -326,7 +326,7 @@ class SimpleCalendar {
         }
         
         .month-link:hover {
-          color: #007bff;
+          color: var(--accent, #8A2E35);
           text-decoration: underline;
         }
         
@@ -472,7 +472,7 @@ class SimpleCalendar {
         }
         
         .event-item-large {
-          background: #007bff;
+          background: var(--accent, #8A2E35);
           color: white;
           padding: 1px 3px;
           border-radius: 2px;
@@ -609,10 +609,10 @@ class SimpleCalendar {
     viewControls.innerHTML = `
       <h6 class="sidebar-title">Ansicht</h6>
       <div class="btn-group-vertical w-100" role="group">
-        <button class="btn btn-outline-primary view-btn ${this.currentView === 'year' ? 'active' : ''}" data-view="year">
+        <button class="btn btn-outline-secondary view-btn ${this.currentView === 'year' ? 'active' : ''}" data-view="year">
           <i class="bi bi-calendar3"></i> Jahr
         </button>
-        <button class="btn btn-outline-primary view-btn ${this.currentView === 'month' ? 'active' : ''}" data-view="month">
+        <button class="btn btn-outline-secondary view-btn ${this.currentView === 'month' ? 'active' : ''}" data-view="month">
           <i class="bi bi-calendar-month"></i> Monat
         </button>
       </div>
@@ -815,8 +815,8 @@ class SimpleCalendar {
         }
         
         .view-controls-sidebar .btn.active {
-          background-color: #007bff;
-          border-color: #007bff;
+          background-color: var(--accent, #8A2E35);
+          border-color: var(--accent, #8A2E35);
           color: white;
           box-shadow: 0 2px 4px rgba(0,123,255,0.3);
         }
@@ -862,7 +862,7 @@ class SimpleCalendar {
         }
         
         .legend-item-sidebar:not(.disabled) .legend-toggle {
-          background: linear-gradient(135deg, var(--category-color, #007bff) 0%, var(--category-color, #007bff) 100%);
+          background: linear-gradient(135deg, var(--category-color, var(--accent, #8A2E35)) 0%, var(--category-color, var(--accent, #8A2E35)) 100%);
           color: white;
           font-weight: 500;
         }

--- a/html/js/timeline-statistics.js
+++ b/html/js/timeline-statistics.js
@@ -232,10 +232,10 @@ function createEventTypeCheckboxes() {
     toggleWrapper.innerHTML = `
         <div class="btn-group w-100" role="group">
             <input type="radio" class="btn-check" name="viewMode" id="mainTypes" autocomplete="off" ${!showSubTypes ? 'checked' : ''}>
-            <label class="btn btn-outline-primary btn-sm" for="mainTypes">Haupttypen</label>
+            <label class="btn btn-outline-secondary btn-sm" for="mainTypes">Haupttypen</label>
             
             <input type="radio" class="btn-check" name="viewMode" id="subTypes" autocomplete="off" ${showSubTypes ? 'checked' : ''}>
-            <label class="btn btn-outline-primary btn-sm" for="subTypes">Untertypen</label>
+            <label class="btn btn-outline-secondary btn-sm" for="subTypes">Untertypen</label>
         </div>
     `;
     eventTypeCheckboxes.appendChild(toggleWrapper);

--- a/xslt/index.xsl
+++ b/xslt/index.xsl
@@ -24,7 +24,7 @@
                 </xsl:call-template>
                 <meta name="google-site-verification" content="dc888ZmCroA0_VKEB86Vss7wy4Jbkaro0j2QfM8GOak" />
             </head>
-            <body class="page" style="background-color:#f1f1f1;">
+            <body class="page">
                 <div class="hfeed site" id="page">
                     <xsl:call-template name="nav_bar"/>
                     <div class="container">
@@ -41,9 +41,7 @@
                                         Sophie Kühnel</h4>
                                     <div style="text-align: right">
                                         <a href="#body">
-                                            <button class="btn btn-round"
-                                                style="background-color: #6B4C5A; color: white;"
-                                                >Weiter</button>
+                                            <button class="btn btn-round">Weiter</button>
                                         </a>
                                     </div>
                                 </div>

--- a/xslt/listevent.xsl
+++ b/xslt/listevent.xsl
@@ -28,11 +28,14 @@
                 <xsl:call-template name="nav_bar"/>
                 <main class="flex-shrink-0 flex-grow-1">
                     <div class="container">
-                        <h1>
-                            <xsl:text>Verzeichnis der Veranstaltungen</xsl:text>
-                        </h1>
-                        <div class="text-center p-1"><span id="counter1"/> von <span id="counter2"/>
-                            Ereignissen</div>
+                        <header class="page-head">
+                            <p class="page-kicker">Veranstaltungen</p>
+                            <h1>
+                                <xsl:text>Verzeichnis der Veranstaltungen</xsl:text>
+                            </h1>
+                            <p class="page-sub"><span id="counter1"/> von <span id="counter2"/>
+                                Ereignissen</p>
+                        </header>
                         <table class="table table-sm display" id="tabulator-table-event">
                             <thead>
                                 <tr>

--- a/xslt/listorg.xsl
+++ b/xslt/listorg.xsl
@@ -24,13 +24,14 @@
                 <div class="hfeed site" id="page">
                     <xsl:call-template name="nav_bar"/>
                     <div class="container">
-                        <div class="card">
-                            <div class="card-header" style="text-align:center">
-                                <h1>
-                                    <xsl:value-of select="$doc_title"/>
-                                </h1>
-                            </div>
-                            <div class="card-body">
+                        <header class="page-head">
+                            <p class="page-kicker">Register</p>
+                            <h1>
+                                <xsl:value-of select="$doc_title"/>
+                            </h1>
+                        </header>
+                        <div>
+                            <div>
                                 <div id="container" class="mb-3"
                                     style="max-width:1200px; margin: 0 auto; width: 100%;">
                                     <table class="table table-sm display" id="tabulator-table-org">

--- a/xslt/listperson.xsl
+++ b/xslt/listperson.xsl
@@ -25,15 +25,14 @@
                 <div class="hfeed site" id="page">
                     <xsl:call-template name="nav_bar"/>
                     <div class="container">
-                        <div class="card">
-                            <div class="card-header" style="text-align:center">
-                                <h1>
-                                    <xsl:value-of select="$doc_title"/>
-                                </h1>
-                            </div>
-                            <div class="card-body">
-                                <div id="container mb-3"
-                                    style="width:100%; margin: auto minWidth: 100%;"/>
+                        <header class="page-head">
+                            <p class="page-kicker">Register</p>
+                            <h1>
+                                <xsl:value-of select="$doc_title"/>
+                            </h1>
+                        </header>
+                        <div>
+                            <div>
                                 <table class="table table-sm display" id="tabulator-table-person">
                                     <thead>
                                         <tr>

--- a/xslt/listplace.xsl
+++ b/xslt/listplace.xsl
@@ -35,14 +35,15 @@
             <body class="page">
                 <div class="hfeed site" id="page">
                     <xsl:call-template name="nav_bar"/>
-                    <div class="container-fluid">
-                        <div class="card">
-                            <div class="card-header" style="text-align:center">
-                                <h1>
-                                    <xsl:value-of select="$doc_title"/>
-                                </h1>
-                            </div>
-                            <div class="card-body">
+                    <div class="container">
+                        <header class="page-head">
+                            <p class="page-kicker">Register</p>
+                            <h1>
+                                <xsl:value-of select="$doc_title"/>
+                            </h1>
+                        </header>
+                        <div>
+                            <div>
                                 <div id="map"/>
                                 <div style="display: flex; justify-content: center;">
                                     <table id="placesTable" style="width:100%; margin: auto;">

--- a/xslt/listwork.xsl
+++ b/xslt/listwork.xsl
@@ -24,9 +24,12 @@
                 <div class="hfeed site" id="page">
                     <xsl:call-template name="nav_bar"/>
                     <div class="container">
-                        <h1>
-                            <xsl:value-of select="$doc_title"/>
-                        </h1>
+                        <header class="page-head">
+                            <p class="page-kicker">Register</p>
+                            <h1>
+                                <xsl:value-of select="$doc_title"/>
+                            </h1>
+                        </header>
                         <div>
                             <div id="container" class="mb-3"
                                 style="max-width:1200px; margin: 0 auto; width: 100%;">

--- a/xslt/partials/html_navbar.xsl
+++ b/xslt/partials/html_navbar.xsl
@@ -6,9 +6,10 @@
         <header class="site-header">
             <nav aria-label="Primary" class="navbar navbar-expand-md site-nav">
                 <div class="container-fluid site-nav-inner">
-                    <a href="index.html" class="navbar-brand brand-wordmark" rel="home">
-                        <span class="brand-name">Schnitzler</span>
-                        <span class="brand-sub">Kulturveranstaltungen</span>
+                    <a href="index.html" class="navbar-brand custom-logo-link" rel="home"
+                        itemprop="url">
+                        <img src="./images/schnitzler-kultur.svg" class="site-logo"
+                            title="schnitzler-kultur" alt="schnitzler-kultur" itemprop="logo"/>
                     </a>
                     <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
                         data-bs-target="#navbarSupportedContent"
@@ -151,13 +152,6 @@
                                         <a class="dropdown-item" href="imprint.html">Impressum</a>
                                     </li>
                                 </ul>
-                            </li>
-                            <li class="nav-item nav-item-search">
-                                <a class="search-pill" href="listevent.html"
-                                    title="Veranstaltungen durchsuchen und filtern">
-                                    <i class="bi bi-search" aria-hidden="true"/>
-                                    <span>Suche</span>
-                                </a>
                             </li>
                         </ul>
                     </div>

--- a/xslt/partials/tabulator_js.xsl
+++ b/xslt/partials/tabulator_js.xsl
@@ -4,7 +4,8 @@
     
     
     <xsl:template match="/" name="tabulator_dl_buttons">
-        <h4>Tabelle laden</h4>
+        <div class="dl-section">
+        <h2 class="event-section-title">Tabelle laden</h2>
         <div class="button-group">
             <button type="button" class="btn btn-outline-secondary" id="download-csv"
                 title="Download CSV">
@@ -33,6 +34,7 @@
                 table.download("html", "daten.html", {style: true});
                 });
             </script>
+        </div>
         </div>
     </xsl:template>
 </xsl:stylesheet>

--- a/xslt/simple-calendar.xsl
+++ b/xslt/simple-calendar.xsl
@@ -23,20 +23,19 @@
                 <div class="hfeed site" id="page">
                     <xsl:call-template name="nav_bar"/>
 
-                    <div class="container-fluid">
-                        <div class="card">
-                            <div class="card-header" style="text-align:center">
-                                <h1 style="display:inline-block;margin-bottom:0;padding-right:5px;">Kalender</h1>
-                                <a>
-                                    <i class="fas fa-info"
-                                        title="Kulturelle Ereignisse nach Tagen und Kategorien"
-                                        data-bs-toggle="modal" data-target="#calendarModal"/>
-                                </a>
-                                <a style="padding-left:5px;" href="js-data/calendarData.js">
-                                    <i class="fas fa-download" title="Kalenderdaten herunterladen"/>
-                                </a>
-                            </div>
-                            <div class="card-body">
+                    <div class="container">
+                        <header class="page-head">
+                            <p class="page-kicker">Veranstaltungen</p>
+                            <h1>Kalender</h1>
+                            <p class="page-sub">
+                                <a href="#" data-bs-toggle="modal" data-bs-target="#calendarModal"
+                                    >Über diese Ansicht</a>
+                                <xsl:text> · </xsl:text>
+                                <a href="js-data/calendarData.js">Kalenderdaten (JS) ↓</a>
+                            </p>
+                        </header>
+                        <div>
+                            <div>
                                 <div class="row">
                                     <div class="col-lg-2 col-md-3 col-sm-12 yearscol">
                                         <div class="row justify-content-md-center" id="years-table"></div>

--- a/xslt/statistik-zeitachse.xsl
+++ b/xslt/statistik-zeitachse.xsl
@@ -25,8 +25,11 @@
                 <xsl:call-template name="nav_bar"/>
                 <main class="flex-shrink-0 flex-grow-1">
                     <div class="container">
-                        <h1>Zeitachsen-Statistik</h1>
-                        <div class="mb-4 mx-auto" style="max-width: 1200px;">
+                        <header class="page-head">
+                            <p class="page-kicker">Statistik</p>
+                            <h1>Zeitachsen-Statistik</h1>
+                        </header>
+                        <div class="mb-4 page-intro">
                             <p>Diese Statistik zeigt die zeitliche Entwicklung verschiedener Ereignistypen über die gesamte erfasste Zeitspanne von 1876 bis 1931. 
                             Sie können einen oder mehrere Ereignistypen auswählen, um deren Verlauf über die Zeit zu vergleichen.</p>
                             <p>Wählen Sie die Ereignistypen aus, die Sie visualisieren möchten. Die verschiedenen Typen werden in unterschiedlichen Farben dargestellt, 
@@ -41,7 +44,7 @@
                                     </div>
                                     <div class="card-body">
                                         <div class="mb-3">
-                                            <button type="button" class="btn btn-sm btn-outline-primary me-2" id="selectAllBtn" aria-label="Alle Ereignistypen auswählen">Alle auswählen</button>
+                                            <button type="button" class="btn btn-sm btn-outline-secondary me-2" id="selectAllBtn" aria-label="Alle Ereignistypen auswählen">Alle auswählen</button>
                                             <button type="button" class="btn btn-sm btn-outline-secondary" id="deselectAllBtn" aria-label="Alle Ereignistypen abwählen">Alle abwählen</button>
                                         </div>
                                         <div id="eventTypeCheckboxes" role="group" aria-labelledby="eventTypeHeader">

--- a/xslt/statistik.xsl
+++ b/xslt/statistik.xsl
@@ -27,10 +27,13 @@
                 <xsl:call-template name="nav_bar"/>
                 <main class="flex-shrink-0 flex-grow-1">
                     <div class="container">
-                        <h1>
-                            <xsl:text>Statistiken</xsl:text>
-                        </h1>
-                        <div class="mb-4 mx-auto" style="max-width: 800px;">
+                        <header class="page-head">
+                            <p class="page-kicker">Statistik</p>
+                            <h1>
+                                <xsl:text>Statistiken</xsl:text>
+                            </h1>
+                        </header>
+                        <div class="mb-4 page-intro">
                             <p>Auf dieser Seite finden sich die Arten von Veranstaltungen, die
                                 Arthur Schnitzler besuchte, in sechs Kategorien (»Theater«, »Musik«,
                                 »Film«, »Vortrag«, »anderes« und »Privatveranstaltung«) eingeteilt


### PR DESCRIPTION
## Zusammenfassung

Rollt die Formensprache der neuen Ereignisseite (PR #3) auf die übrigen Seiten aus — **ohne** `entities.xsl` (Entity-Einzelseiten werden andernorts verwaltet). Zusätzlich drei Design-Korrekturen auf Wunsch der Herausgeber:

- **Weißer Hintergrund** statt des warmen Weiß (`--bg: #FFFFFF`).
- **Suchfenster entfernt** (Such-Pill aus der Navigation).
- **Ursprüngliches Logo** links oben wiederhergestellt (statt Text-Wortmarke).

### Änderungen im Einzelnen

- **Gemeinsame Formensprache** (`theme.css`): Seitenkopf mit Kicker + linksbündigem Titel (`.page-head`), Tabulator-Tabellen als Karten mit Rahmen und getöntem Header, gestalteter Download-Bereich, Formularelemente in Akzentfarbe statt Bootstrap-Blau.
- **Veranstaltungsliste**: neuer Seitenkopf mit Live-Zähler.
- **Register** (Personen, Werke, Orte, Organisationen): Card-Wrapper ersetzt durch Seitenkopf mit Kicker „Register"; Karte der Orte-Seite mit Rahmen.
- **Kalender**: Seitenkopf mit Textlinks statt unsichtbarer FontAwesome-Icons; dabei defektes Modal-Attribut repariert (`data-target` → `data-bs-target`); Jahres-/Ansicht-Buttons von Bootstrap-Blau auf Bordeaux umgestellt.
- **Statistik + Zeitachse**: Seitenköpfe, linksbündige Intros, Karten mit Rahmen, Toggle-Buttons entbläut.
- **Startseite**: Alt-Grau (`#f1f1f1`) und Alt-Mauve (`#6B4C5A`) durch Tokens ersetzt.

## Test

- Voller `ant`-Build erfolgreich.
- Desktop-Screenshots (1440 px) von Liste, Registern, Kalender, Statistik, Zeitachse, Start- und Ereignisseite geprüft.
- Mobile-Audit (375 px) über 14 Seiten: kein horizontales Scrollen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)